### PR TITLE
Add GitHub CI/CD

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+- .
+helm-extra-args: --timeout 600s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: Lint and Test Chart
+
+on:
+  pull_request:
+    # Only if there are chart changes to test.
+    paths:
+    - 'chart/**'
+
+jobs:
+  lint-chart:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Fetch history
+      run: git fetch --prune --unshallow
+
+    - name: Run chart-testing (lint)
+      uses: helm/chart-testing-action@v1.0.0
+      with:
+        command: lint
+        config: .github/ct.yaml
+
+  install-chart:
+    name: install-chart
+    runs-on: ubuntu-latest
+    needs:
+      - lint-chart
+    strategy:
+      matrix:
+        k8s:
+        - v1.17.5
+        - v1.19.1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Fetch history
+      run: git fetch --prune --unshallow
+
+    - name: Create kind ${{ matrix.k8s }} cluster
+      uses: helm/kind-action@v1.0.0
+      with:
+        node_image: kindest/node:${{ matrix.k8s }}
+
+    - name: Run chart-testing (install)
+      uses: helm/chart-testing-action@v1.0.0
+      with:
+        command: install
+        config: .github/ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+name: Release Chart
+
+on:
+  push:
+    branches:
+    - main
+    # Only if there are chart changes to release.
+    paths:
+    - 'chart/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Fetch history
+      run: git fetch --prune --unshallow
+
+    - name: Get helm chart version
+      id: version
+      run: |
+        chart=$(grep "version" chart/Chart.yaml | head -1 | awk '{print $2}')
+        echo "::set-output name=chart::$chart"
+
+    - name: Configure Git
+      run: |
+        git config --global user.name "$GITHUB_ACTOR"
+        git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install Chartpress
+      run: |
+        python -m pip install --upgrade pip
+        pip install chartpress
+
+    - name: Publish Chart to the remote dNationCloud helm repository
+      run: chartpress --publish-chart --tag ${{ steps.version.outputs.chart }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
+
+    - name: Tag branch
+      uses: anothrNick/github-tag-action@1.26.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
+        CUSTOM_TAG: 'v${{ steps.version.outputs.chart }}'
+        RELEASE_BRANCHES: main

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/jupyterhub/chartpress#configuration
+charts:
+- name: chart
+  repo:
+    git: dNationCloud/helm-hub
+    published: https://dnationcloud.github.io/helm-hub/


### PR DESCRIPTION
GitHub CI/CD adds:
- `Lint and Test Chart` pipeline executes only if there are chart changes to test
  - helm lint (with helm chart version check) - job failed if some chart changes were provided but helm chart version was not increased 
  - helm install check on the k8s v1.17.5 and v1.19.1
- `Release Chart` pipeline executes only if there are chart changes to release
  - Publish Chart to the remote [dNationCloud helm repository](https://github.com/dNationCloud/helm-hub)
  - Tag `main` branch with chart version value in following format: `v<chart-version>`