### PR TITLE
Add support for k8s version 1.24+

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,8 +15,8 @@
 
 apiVersion: v2
 name: dnation-kubernetes-monitoring
-version: 2.3.1
-appVersion: 2.3.1
+version: 2.4.0
+appVersion: 2.4.0
 description: A set of Grafana dashboards and Prometheus alerts to cover Kubernetes monitoring in an easy way using a drill-down principle.
 keywords:
 - dnation

--- a/jsonnet/templates.libsonnet
+++ b/jsonnet/templates.libsonnet
@@ -150,11 +150,11 @@
     },
     RecordRules: [
       {
-        expr: 'node_uname_info{job=~"node-exporter"} and on(nodename) label_replace(kube_node_role{role=~"master"}, "nodename", "$1", "node", "(.+)")',
+        expr: 'node_uname_info{job=~"node-exporter"} and on(nodename) label_replace(kube_node_role{role=~"control-plane"}, "nodename", "$1", "node", "(.+)")',
         record: 'master_uname_info',
       },
       {
-        expr: 'node_uname_info{job=~"node-exporter"} unless on(nodename) label_replace(kube_node_role{role=~"master"}, "nodename", "$1", "node", "(.+)")',
+        expr: 'node_uname_info{job=~"node-exporter"} unless on(nodename) label_replace(kube_node_role{role=~"control-plane"}, "nodename", "$1", "node", "(.+)")',
         record: 'worker_uname_info',
       },
     ],


### PR DESCRIPTION
After kubernetes 1.24 version, kubeadm do not add this label `node-role.kubernetes.io/master=` to control-plane nodes automatically.  Cause of this change we need to adjust `master_uname_info` and `worker_uname_info`