### PR TITLE
Preserve cluster label for alerts

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -21,6 +21,17 @@ Search for `Monitoring` dashboard. The fun starts here :).
 If you want to set the `Monitoring` dashboard as a home dashboard follow [here](https://grafana.com/docs/grafana/latest/administration/change-home-dashboard/#set-the-default-dashboard-through-preferences).
 If you're experiencing issues please read the [documentation](https://dnationcloud.github.io/kubernetes-monitoring/docs/documentation) and [FAQ](https://dnationcloud.github.io/kubernetes-monitoring/helpers/FAQ/).
 
+You should set the external label `cluster` for your Prometheus instance and this label should be
+the same, as the one defined in the label field in [values.yaml](chart/values.yaml) for your cluster monitoring.
+E.g., if you installed Prometheus via kube-prometheus-stack helm chart:
+```yaml
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      externalLabels:
+        cluster: "observer-cluster"
+```
+
 ## Configuration
 
 Default values for dNation Kubernetes Monitoring are defined by merging of jsonnet/config.libsonnet and chart/values.yaml files.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,8 +15,8 @@
 
 apiVersion: v2
 name: dnation-kubernetes-monitoring
-version: 2.5.4
-appVersion: 2.5.4
+version: 2.6.0
+appVersion: 2.6.0
 description: A set of Grafana dashboards and Prometheus alerts to cover Kubernetes monitoring in an easy way using a drill-down principle.
 keywords:
 - dnation

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -82,6 +82,7 @@ clusterMonitoring:
   enabled: true
   clusters:
   - name: K8sCluster
+    label: observer-cluster  # The label should be the same as the external_label `cluster` from prometheus
     description: 'Kubernetes cluster monitoring'
     apps: []
     # Kubernetes Application Monitoring could be defined by ServiceMonitor or PodMonitor CRDs. See following links and examples:

--- a/helpers/FAQ.md
+++ b/helpers/FAQ.md
@@ -12,7 +12,7 @@ When some threshold is crossed and this state  persists for **5** minutes (defau
 The orange state panel  with `Warning` label is displayed in case of warning alert. Red state panel with  `Critical` label is displayed in case of critical alert.
 We have implemented intuitive green, orange and red color indicators that are signalizing if your action is needed or if everything is OK.
 If you want to see more information about your k8s cluster, just drill down by left-clicking on
-the relevant state panel. As of now, multi-cluster monitoring support is avaible.
+the relevant state panel. As of now, multi-cluster monitoring support is available.
 
 - If you are interested in the k8s cluster monitoring see [How to set up k8s cluster monitoring?](#how-to-set-up-k8s-cluster-monitoring) section.
 - If you are interested in the k8s multi-cluster monitoring see [How to set up k8s multi-cluster monitoring?](#how-to-set-up-k8s-multi-cluster-monitoring) section.
@@ -139,6 +139,7 @@ clusterMonitoring:
   enabled: true
   clusters:
   - name: K8sCluster
+    label: observer-cluster  # The label should be the same as the external_label `cluster` from prometheus
     description: 'Kubernetes cluster monitoring'
     apps: []
 ```
@@ -189,6 +190,7 @@ clusterMonitoring:
   enabled: true
   clusters:
   - name: K8sCluster
+    label: observer-cluster  # The label should be the same as the external_label `cluster` from prometheus
     description: 'Kubernetes cluster with application monitoring'
     apps:
     - name: app-example
@@ -198,7 +200,7 @@ clusterMonitoring:
         javaActuator:  # Application Exporter template
           enabled: true
       serviceMonitor:
-        jobLabel: app # The label to use to retrieve the job name from.
+        jobLabel: app  # The label to use to retrieve the job name from.
         namespaceSelector:  # Namespaces to transfer from the kubernetes service to the target
           matchNames:
           - default

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -21,7 +21,7 @@ If you want to test your local changes in local KinD k8s cluster use following s
 
 1. Create KinD cluster
 ```bash
-kind create cluster --config helpers/kind_cluster_config.yaml --image kindest/node:v1.22.1
+kind create cluster --config helpers/kind_cluster_config.yaml --image kindest/node:v1.25.11
 ```
 1. Install kubernetes-monitoring-stack (without dNation Kubernetes Monitoring dependency)
 K8s-m8g-stack is an umbrella helm chart which deploys Grafana, Loki and Prometheus Operator projects.
@@ -36,7 +36,7 @@ helm install dnation-kubernetes-monitoring-stack dnationcloud/dnation-kubernetes
 
 1. Follow installation notes and use Port Forwarding if you want to access the Grafana server from outside your KinD cluster
 ```bash
- export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=dnation-kubernetes-monitoring-stack" -o jsonpath="{.items[0].metadata.name}")
+export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=dnation-kubernetes-monitoring-stack" -o jsonpath="{.items[0].metadata.name}")
 kubectl --namespace default port-forward $POD_NAME 3000
 ```
 

--- a/helpers/kind_cluster_config.yaml
+++ b/helpers/kind_cluster_config.yaml
@@ -26,7 +26,7 @@ nodes:
       kind: KubeProxyConfiguration
       metricsBindAddress: 0.0.0.0:10249
     - |
-      apiVersion: kubeadm.k8s.io/v1beta2
+      apiVersion: kubeadm.k8s.io/v1beta3
       kind: ClusterConfiguration
       etcd:
         local:

--- a/helpers/values-cluster-elk.yaml
+++ b/helpers/values-cluster-elk.yaml
@@ -19,6 +19,7 @@ clusterMonitoring:
   enabled: true
   clusters:
   - name: K8sCluster
+    label: observer-cluster
     description: 'Kubernetes cluster monitoring'
     templates:
       mostUtilizedPVCELK:

--- a/helpers/values-cluster-prom.yaml
+++ b/helpers/values-cluster-prom.yaml
@@ -19,14 +19,15 @@ clusterMonitoring:
   enabled: true
   clusters:
   - name: K8sCluster
+    label: observer-cluster
     description: 'Kubernetes cluster monitoring'
     templates:
       pvcBound:
         linkTo: ['pvcOverviewTableProm', 'pvcOverviewTableExceptProm']
         panel:
           dataLinks: [
-            { title: 'K8s Overview Except Pro,', url: '/d/{}?%s&refresh=10s&var-datasource=$datasource&var-cluster=$cluster|&from=$__from&to=$__to' },
-            { title: 'K8s Overview Prom', url: '/d/{}?%s&refresh=10s&var-datasource=$datasource&var-cluster=$cluster|&from=$__from&to=$__to' },
+            { title: 'K8s Overview Except Pro,', url: '/d/{}?%s&refresh=10s&var-datasource=$datasource&var-cluster=$cluster&from=$__from&to=$__to' },
+            { title: 'K8s Overview Prom', url: '/d/{}?%s&refresh=10s&var-datasource=$datasource&var-cluster=$cluster&from=$__from&to=$__to' },
           ]
       mostUtilizedPVCProm:
         enabled: true
@@ -85,7 +86,7 @@ templates:
     pvcOverview:
       pvcOverviewTableProm:
         dashboardInfo:
-          grafanaTemplateQuery: 'label_values(kube_persistentvolumeclaim_info{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"prometheus.*\"}, persistentvolumeclaim)'
+          grafanaTemplateQuery: 'label_values(kube_persistentvolumeclaim_info{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"prometheus.*\"}, persistentvolumeclaim)'
         parent: 'pvcOverviewTable'
         default: false
         panel:
@@ -94,31 +95,31 @@ templates:
             { pattern: 'Time', type: 'hidden' },
             { alias: 'Capacity', pattern: 'Value #A', colors: ['green', 'orange', 'red'], colorMode: 'cell', type: 'number', unit: 'percent', thresholds: [30, 40] },
             { alias: 'Status', pattern: 'Value #B', colors: ['green', 'orange', 'red'], colorMode: 'cell', type: 'string', thresholds: [2, 2], valueMaps: [{ text: 'Bound', value: 1 }, { text: 'Lost', value: 2 }, { text: 'Pending', value: 3 }], mappingType: 1 },
-            { alias: 'PVC', pattern: 'persistentvolumeclaim', link: true, linkTooltip: 'Detail', linkUrl: '/d/persistentvolumes?var-namespace=${__cell_1}&var-pvc=${__cell_2}&refresh=10s&var-datasource=$datasource&var-cluster=$cluster|&from=$__from&to=$__to'},
+            { alias: 'PVC', pattern: 'persistentvolumeclaim', link: true, linkTooltip: 'Detail', linkUrl: '/d/persistentvolumes?var-namespace=${__cell_1}&var-pvc=${__cell_2}&refresh=10s&var-datasource=$datasource&var-cluster=$cluster&from=$__from&to=$__to'},
             { alias: 'Namespace', pattern: 'namespace', type: 'string' },
           ]
           expr: [
-              'sum by (persistentvolumeclaim, namespace) (((kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim=~\"prometheus.*\"} - kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) * 100)',
+              'sum by (persistentvolumeclaim, namespace) (((kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim=~\"prometheus.*\"} - kubelet_volume_stats_available_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) / kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) * 100)',
               '
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim=~\"prometheus.*\", phase=\"Bound\"} * 1) +
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Lost\"} * 2) +
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Pending\"} * 3)
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim=~\"prometheus.*\", phase=\"Bound\"} * 1) +
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Lost\"} * 2) +
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Pending\"} * 3)
               ',
           ]
 
       pvcOverviewTableExceptProm:
         dashboardInfo:
-          grafanaTemplateQuery: 'label_values(kube_persistentvolumeclaim_info{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim!~\"prometheus.*\"}, persistentvolumeclaim)'
+          grafanaTemplateQuery: 'label_values(kube_persistentvolumeclaim_info{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim!~\"prometheus.*\"}, persistentvolumeclaim)'
         parent: 'pvcOverviewTable'
         default: false
         panel:
           title: 'PVC except Prom'
           expr: [
-              'sum by (persistentvolumeclaim, namespace) (((kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim!~\"prometheus.*\"} - kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) * 100)',
+              'sum by (persistentvolumeclaim, namespace) (((kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim!~\"prometheus.*\"} - kubelet_volume_stats_available_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) / kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\"}) * 100)',
               '
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim!~\"prometheus.*\", phase=\"Bound\"} * 1) +
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Lost\"} * 2) +
-                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Pending\"} * 3)
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", persistentvolumeclaim!~\"prometheus.*\", phase=\"Bound\"} * 1) +
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Lost\"} * 2) +
+                sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_status_phase{cluster=\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"$pvc\", phase=\"Pending\"} * 3)
               ',
           ]
 

--- a/jsonnet/config.libsonnet
+++ b/jsonnet/config.libsonnet
@@ -57,7 +57,7 @@
         critical: 'red',
         invalid: 'black',  // invalid range is always from minus infinity to 'lowest' thredhold if it is defined
       },
-      dataLinkCommonArgs: 'refresh=%s&var-datasource=$datasource&var-cluster=$cluster|&from=$__from&to=$__to' % [self.refresh],
+      dataLinkCommonArgs: 'refresh=%s&var-datasource=$datasource&var-cluster=$cluster&from=$__from&to=$__to' % [self.refresh],
       dataLinkCommonArgsNoCluster: 'refresh=%s&var-datasource=$datasource&from=$__from&to=$__to' % [self.refresh],
       templateRefresh: 'time',  // on time range change
       templateSort: 5,  // case insensitive ascent sort

--- a/jsonnet/dashboards/apps/apache.libsonnet
+++ b/jsonnet/dashboards/apps/apache.libsonnet
@@ -30,7 +30,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(apache__req_per_sec{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='requests'));
+        .addTarget(prometheus.target('rate(apache__req_per_sec{cluster="$cluster", job=~"$job"}[5m])', legendFormat='requests'));
 
       local cpuLoad =
         graphPanel.new(
@@ -39,7 +39,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(apache__c_p_u_load{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='load'));
+        .addTarget(prometheus.target('rate(apache__c_p_u_load{cluster="$cluster", job=~"$job"}[5m])', legendFormat='load'));
 
       local memoryUtilization =
         graphPanel.new(
@@ -49,7 +49,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(apache__total_k_bytes_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='total'));
+        .addTarget(prometheus.target('rate(apache__total_k_bytes_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='total'));
 
       local memoryUtilizationPer =
         graphPanel.new(
@@ -61,8 +61,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(apache__bytes_per_sec{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='bytes per sec'),
-            prometheus.target('rate(apache__bytes_per_req{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='bytes per req'),
+            prometheus.target('rate(apache__bytes_per_sec{cluster="$cluster", job=~"$job"}[5m])', legendFormat='bytes per sec'),
+            prometheus.target('rate(apache__bytes_per_req{cluster="$cluster", job=~"$job"}[5m])', legendFormat='bytes per req'),
           ],
         );
 
@@ -73,8 +73,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(apache__idle_workers{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='idle'),
-            prometheus.target('rate(apache__busy_workers{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='busy'),
+            prometheus.target('rate(apache__idle_workers{cluster="$cluster", job=~"$job"}[5m])', legendFormat='idle'),
+            prometheus.target('rate(apache__busy_workers{cluster="$cluster", job=~"$job"}[5m])', legendFormat='busy'),
           ],
         );
 
@@ -102,7 +102,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(apache__c_p_u_load{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(apache__c_p_u_load{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/autoscaler.libsonnet
+++ b/jsonnet/dashboards/apps/autoscaler.libsonnet
@@ -30,9 +30,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(autoscaler_instances{cluster=~"$cluster", job=~"$job"})', legendFormat='instances'),
-            prometheus.target('sum(autoscaler_healthy{cluster=~"$cluster", job=~"$job"})', legendFormat='instances healthy'),
-            prometheus.target('sum(autoscaler_groups{cluster=~"$cluster", job=~"$job"})', legendFormat='groups'),
+            prometheus.target('sum(autoscaler_instances{cluster="$cluster", job=~"$job"})', legendFormat='instances'),
+            prometheus.target('sum(autoscaler_healthy{cluster="$cluster", job=~"$job"})', legendFormat='instances healthy'),
+            prometheus.target('sum(autoscaler_groups{cluster="$cluster", job=~"$job"})', legendFormat='groups'),
           ],
         );
 
@@ -53,7 +53,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(autoscaler_instances{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(autoscaler_instances{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/cadvisor.libsonnet
+++ b/jsonnet/dashboards/apps/cadvisor.libsonnet
@@ -33,7 +33,7 @@ local table = grafana.tablePanel;
         )
         .addThresholds($.grafanaThresholds($._config.templates.L1.hostApps.genericApp.panel.thresholds))
         .addTarget(
-          prometheus.target('count(rate(container_last_seen{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m]))')
+          prometheus.target('count(rate(container_last_seen{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m]))')
         );
 
       local imageTable =
@@ -47,7 +47,7 @@ local table = grafana.tablePanel;
             { pattern: 'Value', type: 'hidden' },
           ]
         )
-        .addTarget(prometheus.target(format='table', instant=true, expr='sum(container_cpu_user_seconds_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}) by (name,image)'));
+        .addTarget(prometheus.target(format='table', instant=true, expr='sum(container_cpu_user_seconds_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}) by (name,image)'));
 
       local cpu =
         graphPanel.new(
@@ -61,7 +61,7 @@ local table = grafana.tablePanel;
           linewidth=2,
           fill=2,
         )
-        .addTarget(prometheus.target('rate(container_cpu_user_seconds_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m]) * 100', legendFormat='{{name}}'));
+        .addTarget(prometheus.target('rate(container_cpu_user_seconds_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m]) * 100', legendFormat='{{name}}'));
 
       local memory =
         graphPanel.new(
@@ -72,7 +72,7 @@ local table = grafana.tablePanel;
           linewidth=2,
           fill=2,
         )
-        .addTarget(prometheus.target('container_memory_usage_bytes{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}', legendFormat='{{name}}'));
+        .addTarget(prometheus.target('container_memory_usage_bytes{cluster="$cluster", job=~"$job", image!="", name=~"$container"}', legendFormat='{{name}}'));
 
       local containerDiskUsage =
         graphPanel.new(
@@ -83,7 +83,7 @@ local table = grafana.tablePanel;
           fill=2,
           min=0,
         )
-        .addTarget(prometheus.target('container_fs_usage_bytes{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}', legendFormat='{{name}}'));
+        .addTarget(prometheus.target('container_fs_usage_bytes{cluster="$cluster", job=~"$job", image!="", name=~"$container"}', legendFormat='{{name}}'));
 
       local DiskIO =
         graphPanel.new(
@@ -97,9 +97,9 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/io time*/', yaxis: 2 })
         .addTargets(
           [
-            prometheus.target('sum(rate(container_fs_reads_bytes_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='read {{name}}'),
-            prometheus.target('sum(rate(container_fs_writes_bytes_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='written {{name}}'),
-            prometheus.target('sum(rate(container_fs_io_time_seconds_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='io time {{name}}'),
+            prometheus.target('sum(rate(container_fs_reads_bytes_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='read {{name}}'),
+            prometheus.target('sum(rate(container_fs_writes_bytes_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='written {{name}}'),
+            prometheus.target('sum(rate(container_fs_io_time_seconds_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])) by (name)', legendFormat='io time {{name}}'),
           ],
         );
 
@@ -117,8 +117,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('irate(container_network_transmit_bytes_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
-            prometheus.target('irate(container_network_receive_bytes_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
+            prometheus.target('irate(container_network_transmit_bytes_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
+            prometheus.target('irate(container_network_receive_bytes_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
           ],
         );
 
@@ -136,8 +136,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
-            prometheus.target('irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
+            prometheus.target('irate(container_network_transmit_packets_dropped_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
+            prometheus.target('irate(container_network_receive_packets_dropped_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
           ],
         );
 
@@ -155,8 +155,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('irate(container_network_transmit_errors_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
-            prometheus.target('irate(container_network_receive_errors_total{cluster=~"$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
+            prometheus.target('irate(container_network_transmit_errors_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Tx_{{name}}'),
+            prometheus.target('irate(container_network_receive_errors_total{cluster="$cluster", job=~"$job", image!="", name=~"$container"}[5m])', legendFormat='Rx_{{name}}'),
           ],
         );
 
@@ -191,8 +191,8 @@ local table = grafana.tablePanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(container_cpu_user_seconds_total{cluster=~"$cluster"}, job)'),
-        $.grafanaTemplates.containerTemplate('label_values(container_cpu_user_seconds_total{cluster=~"$cluster", job=~"$job"}, name)'),
+        $.grafanaTemplates.jobTemplate('label_values(container_cpu_user_seconds_total{cluster="$cluster"}, job)'),
+        $.grafanaTemplates.containerTemplate('label_values(container_cpu_user_seconds_total{cluster="$cluster", job=~"$job"}, name)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/harbor.libsonnet
+++ b/jsonnet/dashboards/apps/harbor.libsonnet
@@ -34,7 +34,7 @@ local row = grafana.row;
           min=0,
           max=1,
         )
-        .addTarget(prometheus.target('harbor_health{cluster=~"$cluster", job=~"$job"}'))
+        .addTarget(prometheus.target('harbor_health{cluster="$cluster", job=~"$job"}'))
         .addThresholds(
           [
             { color: $._config.grafanaDashboards.color.red, value: null },
@@ -47,35 +47,35 @@ local row = grafana.row;
           title='Component Up Status',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_up{cluster=~"$cluster", job=~"$job"}', legendFormat='{{component}}'));
+        .addTarget(prometheus.target('harbor_up{cluster="$cluster", job=~"$job"}', legendFormat='{{component}}'));
 
       local systemInfo =
         graphPanel.new(
           title='System Info',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_system_info{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('harbor_system_info{cluster="$cluster", job=~"$job"}'));
 
       local artifactPulled =
         graphPanel.new(
           title='Artifact Pulled',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_artifact_pulled{cluster=~"$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
+        .addTarget(prometheus.target('harbor_artifact_pulled{cluster="$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
 
       local projectTotal =
         graphPanel.new(
           title='Project Total',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_project_total{cluster=~"$cluster", job=~"$job"}', legendFormat='public="{{public}}"'));
+        .addTarget(prometheus.target('harbor_project_total{cluster="$cluster", job=~"$job"}', legendFormat='public="{{public}}"'));
 
       local projectMembers =
         graphPanel.new(
           title='Project Members',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_project_member_total{cluster=~"$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
+        .addTarget(prometheus.target('harbor_project_member_total{cluster="$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
 
       local quotaUsage =
         graphPanel.new(
@@ -83,56 +83,56 @@ local row = grafana.row;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('harbor_project_quota_usage_byte{cluster=~"$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
+        .addTarget(prometheus.target('harbor_project_quota_usage_byte{cluster="$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
 
       local projectRepoTotal =
         graphPanel.new(
           title='Project Repo Total',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_project_repo_total{cluster=~"$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
+        .addTarget(prometheus.target('harbor_project_repo_total{cluster="$cluster", job=~"$job"}', legendFormat='{{project_name}}'));
 
       local goInfo =
         graphPanel.new(
           title='Go Info',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_info{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_info{cluster="$cluster", job=~"$job"}'));
 
       local processCpuTime =
         graphPanel.new(
           title='Process CPU Time',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", job=~"$job"}[5m])'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", job=~"$job"}[5m])'));
 
       local goThreads =
         graphPanel.new(
           title='Go Threads',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_threads{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_threads{cluster="$cluster", job=~"$job"}'));
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", job=~"$job"}'));
 
       local processOpenedFd =
         graphPanel.new(
           title='Process Opened Fd',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('process_open_fds{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('process_open_fds{cluster="$cluster", job=~"$job"}'));
 
       local goHeapObjects =
         graphPanel.new(
           title='Go Heap Objects',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_memstats_heap_objects{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_memstats_heap_objects{cluster="$cluster", job=~"$job"}'));
 
       local goAllocatedMemory =
         graphPanel.new(
@@ -140,7 +140,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('go_memstats_alloc_bytes{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_memstats_alloc_bytes{cluster="$cluster", job=~"$job"}'));
 
       local goNextGcBytes =
         graphPanel.new(
@@ -148,7 +148,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('go_memstats_next_gc_bytes{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_memstats_next_gc_bytes{cluster="$cluster", job=~"$job"}'));
 
       local goGcTime_025 =
         graphPanel.new(
@@ -156,7 +156,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.25", cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.25", cluster="$cluster", job=~"$job"}'));
 
       local goGcTime_050 =
         graphPanel.new(
@@ -164,7 +164,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.5", cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.5", cluster="$cluster", job=~"$job"}'));
 
       local goGcTime_075 =
         graphPanel.new(
@@ -172,7 +172,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.75", cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('go_gc_duration_seconds{quantile="0.75", cluster="$cluster", job=~"$job"}'));
 
       local apiRequestTime_050 =
         graphPanel.new(
@@ -180,7 +180,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.5", cluster=~"$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
+        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.5", cluster="$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
 
       local apiRequestTime_090 =
         graphPanel.new(
@@ -188,7 +188,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.9", cluster=~"$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
+        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.9", cluster="$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
 
       local apiRequestTime_099 =
         graphPanel.new(
@@ -196,35 +196,35 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.99", cluster=~"$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
+        .addTarget(prometheus.target('harbor_core_http_request_duration_seconds{quantile="0.99", cluster="$cluster", job=~"$job"}', legendFormat='{{instance}}-{{operation}}'));
 
       local harborCoreRequestTotal =
         graphPanel.new(
           title='Harbor Core Request Total',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(harbor_core_http_request_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='{{instance}}-{{operation}}'));
+        .addTarget(prometheus.target('rate(harbor_core_http_request_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='{{instance}}-{{operation}}'));
 
       local harborCoreInflightRequest =
         graphPanel.new(
           title='Harbor Core Inflight Request',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_core_http_inflight_requests{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('harbor_core_http_inflight_requests{cluster="$cluster", job=~"$job"}'));
 
       local jobServiceInfo =
         graphPanel.new(
           title='Job Service Info',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_jobservice_info{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('harbor_jobservice_info{cluster="$cluster", job=~"$job"}'));
 
       local taskQueuePendingSize =
         graphPanel.new(
           title='Task Queue Pending Size',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_task_queue_size{cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}}'));
+        .addTarget(prometheus.target('harbor_task_queue_size{cluster="$cluster", job=~"$job"}', legendFormat='{{type}}'));
 
       local taskLatency =
         graphPanel.new(
@@ -233,28 +233,28 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_task_queue_latency{cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}}'));
+        .addTarget(prometheus.target('harbor_task_queue_latency{cluster="$cluster", job=~"$job"}', legendFormat='{{type}}'));
 
       local taskConcurrency =
         graphPanel.new(
           title='Task Concurrency',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_task_concurrency{cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}}-{{pool}}'));
+        .addTarget(prometheus.target('harbor_task_concurrency{cluster="$cluster", job=~"$job"}', legendFormat='{{type}}-{{pool}}'));
 
       local tasksPerMinute =
         graphPanel.new(
           title='Tasks Per Minute',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(harbor_jobservice_task_total{cluster=~"$cluster", job=~"$job"}[1m])', legendFormat='{{type}} {{status}}'));
+        .addTarget(prometheus.target('rate(harbor_jobservice_task_total{cluster="$cluster", job=~"$job"}[1m])', legendFormat='{{type}} {{status}}'));
 
       local numberRunningScheduledJob =
         graphPanel.new(
           title='Number Of Running Scheduled Job',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('harbor_task_scheduled_total{cluster=~"$cluster", job=~"$job"}'));
+        .addTarget(prometheus.target('harbor_task_scheduled_total{cluster="$cluster", job=~"$job"}'));
 
       local taskProcessTime_050 =
         graphPanel.new(
@@ -262,7 +262,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.5", cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
+        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.5", cluster="$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
 
       local taskProcessTime_090 =
         graphPanel.new(
@@ -270,7 +270,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.9", cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
+        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.9", cluster="$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
 
       local taskProcessTime_099 =
         graphPanel.new(
@@ -278,28 +278,28 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.99", cluster=~"$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
+        .addTarget(prometheus.target('harbor_jobservice_task_process_time_seconds{quantile="0.99", cluster="$cluster", job=~"$job"}', legendFormat='{{type}} {{status}}'));
 
       local registryRequestInflight =
         graphPanel.new(
           title='Registry Request Inflight',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('registry_http_in_flight_requests{cluster=~"$cluster", job=~"$job"}', legendFormat='{{handler}}'));
+        .addTarget(prometheus.target('registry_http_in_flight_requests{cluster="$cluster", job=~"$job"}', legendFormat='{{handler}}'));
 
       local registryRequestRate =
         graphPanel.new(
           title='Registry Request Rate',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(registry_http_requests_total{cluster=~"$cluster", job=~"$job"}[5m])'));
+        .addTarget(prometheus.target('rate(registry_http_requests_total{cluster="$cluster", job=~"$job"}[5m])'));
 
       local registryStorageCache =
         graphPanel.new(
           title='Registry Storage Cache',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(registry_storage_cache_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='{{type}}'));
+        .addTarget(prometheus.target('rate(registry_storage_cache_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='{{type}}'));
 
       local registryRequestTime_050 =
         graphPanel.new(
@@ -307,7 +307,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.5, rate(registry_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.5, rate(registry_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local registryRequestTime_090 =
         graphPanel.new(
@@ -315,7 +315,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local registryRequestTime_099 =
         graphPanel.new(
@@ -323,7 +323,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, rate(registry_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, rate(registry_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local registryRequestSize_090 =
         graphPanel.new(
@@ -331,7 +331,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_request_size_bytes_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_request_size_bytes_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local registryResponseSize_090 =
         graphPanel.new(
@@ -339,7 +339,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_response_size_bytes_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_http_response_size_bytes_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local registryStorageActionTime_090 =
         graphPanel.new(
@@ -347,7 +347,7 @@ local row = grafana.row;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_storage_action_seconds_bucket{cluster=~"$cluster", job=~"$job"}[10m]))'));
+        .addTarget(prometheus.target('histogram_quantile(0.9, rate(registry_storage_action_seconds_bucket{cluster="$cluster", job=~"$job"}[10m]))'));
 
       local templates =
         [

--- a/jsonnet/dashboards/apps/java-actuator.libsonnet
+++ b/jsonnet/dashboards/apps/java-actuator.libsonnet
@@ -32,7 +32,7 @@ local row = grafana.row;
           name='jvm_memory_pool_heap',
           label='JVM Memory Pools Heap',
           datasource='$datasource',
-          query='label_values(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", area="heap"},id)',
+          query='label_values(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", area="heap"},id)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -44,7 +44,7 @@ local row = grafana.row;
           name='jvm_memory_pool_nonheap',
           label='JVM Memory Pools Non-Heap',
           datasource='$datasource',
-          query='label_values(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", area="nonheap"},id)',
+          query='label_values(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", area="nonheap"},id)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -66,9 +66,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -87,9 +87,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -107,8 +107,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -126,8 +126,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -147,7 +147,7 @@ local row = grafana.row;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
 
       local logs =
         logPanel.new(
@@ -155,7 +155,7 @@ local row = grafana.row;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
 
       local rate =
         graphPanel.new(
@@ -168,7 +168,7 @@ local row = grafana.row;
           legend_current=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('sum(rate(http_server_requests_seconds_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}[1m]))', legendFormat='HTTP'));
+        .addTarget(prometheus.target('sum(rate(http_server_requests_seconds_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}[1m]))', legendFormat='HTTP'));
 
       local successRate =
         graphPanel.new(
@@ -181,7 +181,7 @@ local row = grafana.row;
           legend_current=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('sum(rate(http_server_requests_seconds_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"[4-5].*"}[1m]))', legendFormat='HTTP - 5xx|4xx'));
+        .addTarget(prometheus.target('sum(rate(http_server_requests_seconds_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"[4-5].*"}[1m]))', legendFormat='HTTP - 5xx|4xx'));
 
       local duration =
         graphPanel.new(
@@ -196,8 +196,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(http_server_requests_seconds_sum{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."}[1m]))/sum(rate(http_server_requests_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."}[1m]))', legendFormat='HTTP - AVG'),
-            prometheus.target('max(http_server_requests_seconds_max{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."})', legendFormat='HTTP - MAX'),
+            prometheus.target('sum(rate(http_server_requests_seconds_sum{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."}[1m]))/sum(rate(http_server_requests_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."}[1m]))', legendFormat='HTTP - AVG'),
+            prometheus.target('max(http_server_requests_seconds_max{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status!~"5.."})', legendFormat='HTTP - MAX'),
           ],
         );
 
@@ -210,7 +210,7 @@ local row = grafana.row;
         )
         .addThresholds($.grafanaThresholds($._config.templates.L1.k8sApps.javaActuator.panel.thresholds))
         .addTarget(
-          prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"})*100/sum(jvm_memory_max_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"})'),
+          prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"})*100/sum(jvm_memory_max_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"})'),
         );
 
       local NonHeapUsed =
@@ -222,7 +222,7 @@ local row = grafana.row;
         )
         .addThresholds($.grafanaThresholds($._config.templates.L1.k8sApps.javaActuator.panel.thresholds))
         .addTarget(
-          prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"})*100/sum(jvm_memory_max_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"})'),
+          prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"})*100/sum(jvm_memory_max_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"})'),
         );
 
       local JvmHeap =
@@ -239,9 +239,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_memory_committed_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='committed - {{$view}}'),
-            prometheus.target('sum(jvm_memory_max_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_memory_committed_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='committed - {{$view}}'),
+            prometheus.target('sum(jvm_memory_max_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="heap"}) by ($view)', legendFormat='max - {{$view}}'),
           ],
         );
 
@@ -259,9 +259,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_memory_committed_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='committed - {{$view}}'),
-            prometheus.target('sum(jvm_memory_max_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_memory_committed_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='committed - {{$view}}'),
+            prometheus.target('sum(jvm_memory_max_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", area="nonheap"}) by ($view)', legendFormat='max - {{$view}}'),
           ],
         );
 
@@ -278,15 +278,15 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_memory_committed_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='committed - {{$view}}'),
-            prometheus.target('sum(jvm_memory_max_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
-            prometheus.target('sum(process_memory_vss_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='vss - {{$view}}'),
-            prometheus.target('sum(process_memory_rss_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='rss - {{$view}}'),
-            prometheus.target('sum(process_memory_pss_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='pss - {{$view}}'),
-            prometheus.target('sum(process_memory_swap_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='swap - {{$view}}'),
-            prometheus.target('sum(process_memory_swappss_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='swappss - {{$view}}'),
-            prometheus.target('sum(process_memory_pss_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) + sum(process_memory_swap_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='phys (pss+swap) - {{$view}}'),
+            prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_memory_committed_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='committed - {{$view}}'),
+            prometheus.target('sum(jvm_memory_max_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(process_memory_vss_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='vss - {{$view}}'),
+            prometheus.target('sum(process_memory_rss_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='rss - {{$view}}'),
+            prometheus.target('sum(process_memory_pss_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='pss - {{$view}}'),
+            prometheus.target('sum(process_memory_swap_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='swap - {{$view}}'),
+            prometheus.target('sum(process_memory_swappss_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='swappss - {{$view}}'),
+            prometheus.target('sum(process_memory_pss_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) + sum(process_memory_swap_bytes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='phys (pss+swap) - {{$view}}'),
           ],
         );
 
@@ -303,10 +303,10 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_threads_live{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(jvm_threads_live_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) ', legendFormat='live - {{$view}}'),
-            prometheus.target('sum(jvm_threads_daemon{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)  or sum(jvm_threads_daemon_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='daemon - {{$view}}'),
-            prometheus.target('sum(jvm_threads_peak{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)  or sum(jvm_threads_peak_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='peak - {{$view}}'),
-            prometheus.target('sum(process_threads{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)', legendFormat='process - {{$view}}'),
+            prometheus.target('sum(jvm_threads_live{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(jvm_threads_live_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) ', legendFormat='live - {{$view}}'),
+            prometheus.target('sum(jvm_threads_daemon{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)  or sum(jvm_threads_daemon_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='daemon - {{$view}}'),
+            prometheus.target('sum(jvm_threads_peak{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)  or sum(jvm_threads_peak_threads{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='peak - {{$view}}'),
+            prometheus.target('sum(process_threads{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by ($view)', legendFormat='process - {{$view}}'),
           ],
         );
 
@@ -327,7 +327,7 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/terminated/', color: $._config.grafanaDashboards.color.purple })
         .addSeriesOverride({ alias: '/timed-waiting/', color: $._config.grafanaDashboards.color.orange })
         .addTarget(
-          prometheus.target('sum(jvm_threads_states_threads{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by (state, $view)', legendFormat='{{state}} - {{$view}}'),
+          prometheus.target('sum(jvm_threads_states_threads{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"})  by (state, $view)', legendFormat='{{state}} - {{$view}}'),
         );
 
       local fileDescriptions =
@@ -344,10 +344,10 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(process_open_fds{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='open - {{$view}}'),
-            prometheus.target('sum(process_max_fds{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
-            prometheus.target('sum(process_files_open{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(process_files_open_files{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='open - {{$view}}'),
-            prometheus.target('sum(process_files_max{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(process_files_max_files{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(process_open_fds{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='open - {{$view}}'),
+            prometheus.target('sum(process_max_fds{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(process_files_open{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(process_files_open_files{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='open - {{$view}}'),
+            prometheus.target('sum(process_files_max{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(process_files_max_files{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='max - {{$view}}'),
           ],
         );
 
@@ -368,7 +368,7 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/info/', color: $._config.grafanaDashboards.color.green })
         .addSeriesOverride({ alias: '/debug/', color: $._config.grafanaDashboards.color.blue })
         .addTarget(
-          prometheus.target('sum(increase(logback_events_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (level, $view)', legendFormat='{{level}} - {{$view}}'),
+          prometheus.target('sum(increase(logback_events_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (level, $view)', legendFormat='{{level}} - {{$view}}'),
         );
 
       local jvmMemoryPoolHeap =
@@ -386,9 +386,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_memory_committed_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='commited - {{$view}}'),
-            prometheus.target('sum(jvm_memory_max_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_memory_committed_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='commited - {{$view}}'),
+            prometheus.target('sum(jvm_memory_max_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="$jvm_memory_pool_heap"}) by ($view)', legendFormat='max - {{$view}}'),
           ],
         );
 
@@ -407,9 +407,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_memory_committed_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='commited - {{$view}}'),
-            prometheus.target('sum(jvm_memory_max_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='max - {{$view}}'),
+            prometheus.target('sum(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_memory_committed_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='commited - {{$view}}'),
+            prometheus.target('sum(jvm_memory_max_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="${jvm_memory_pool_nonheap:raw}"}) by ($view)', legendFormat='max - {{$view}}'),
           ],
         );
 
@@ -422,7 +422,7 @@ local row = grafana.row;
           min=0,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(jvm_gc_pause_seconds_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view)', legendFormat='{{action}} ({{cause}}) - {{$view}}'));
+        .addTarget(prometheus.target('sum(rate(jvm_gc_pause_seconds_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view)', legendFormat='{{action}} ({{cause}}) - {{$view}}'));
 
       local pauseDurations =
         graphPanel.new(
@@ -435,8 +435,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(jvm_gc_pause_seconds_sum{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view) /sum(rate(jvm_gc_pause_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view)', legendFormat='avg {{action}} ({{cause}}) - {{$view}}'),
-            prometheus.target('sum(jvm_gc_pause_seconds_max{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by (action, cause, $view)', legendFormat='max {{action}} ({{cause}}) - {{$view}}'),
+            prometheus.target('sum(rate(jvm_gc_pause_seconds_sum{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view) /sum(rate(jvm_gc_pause_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by (action, cause, $view)', legendFormat='avg {{action}} ({{cause}}) - {{$view}}'),
+            prometheus.target('sum(jvm_gc_pause_seconds_max{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by (action, cause, $view)', legendFormat='max {{action}} ({{cause}}) - {{$view}}'),
           ],
         );
 
@@ -451,8 +451,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(jvm_gc_memory_allocated_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by ($view)', legendFormat='allocated - {{$view}}'),
-            prometheus.target('sum(rate(jvm_gc_memory_promoted_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by ($view)', legendFormat='promoted - {{$view}}'),
+            prometheus.target('sum(rate(jvm_gc_memory_allocated_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by ($view)', legendFormat='allocated - {{$view}}'),
+            prometheus.target('sum(rate(jvm_gc_memory_promoted_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m])) by ($view)', legendFormat='promoted - {{$view}}'),
           ],
         );
 
@@ -464,7 +464,7 @@ local row = grafana.row;
           fill=2,
           min=0,
         )
-        .addTarget(prometheus.target('sum(jvm_classes_loaded{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(jvm_classes_loaded_classes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='loaded - {{$view}}'));
+        .addTarget(prometheus.target('sum(jvm_classes_loaded{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view) or sum(jvm_classes_loaded_classes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='loaded - {{$view}}'));
 
       local classDelta =
         graphPanel.new(
@@ -473,7 +473,7 @@ local row = grafana.row;
           linewidth=2,
           fill=2,
         )
-        .addTarget(prometheus.target('sum(delta(jvm_classes_loaded{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[5m])) by ($view) or sum(delta(jvm_classes_loaded_classes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[5m])) by ($view)', legendFormat='delta - {{$view}}'));
+        .addTarget(prometheus.target('sum(delta(jvm_classes_loaded{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[5m])) by ($view) or sum(delta(jvm_classes_loaded_classes{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[5m])) by ($view)', legendFormat='delta - {{$view}}'));
 
       local directBuffersMemoryUsedBytes =
         graphPanel.new(
@@ -486,8 +486,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_buffer_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_buffer_total_capacity_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='capacity - {{$view}}'),
+            prometheus.target('sum(jvm_buffer_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_buffer_total_capacity_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='capacity - {{$view}}'),
           ],
         );
 
@@ -499,7 +499,7 @@ local row = grafana.row;
           fill=2,
           min=0,
         )
-        .addTarget(prometheus.target('sum(jvm_buffer_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view) or sum(jvm_buffer_count_buffers{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='count - {{$view}}'));
+        .addTarget(prometheus.target('sum(jvm_buffer_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view) or sum(jvm_buffer_count_buffers{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="direct"}) by ($view)', legendFormat='count - {{$view}}'));
 
       local mappedBuffersMemoryUsedBytes =
         graphPanel.new(
@@ -512,8 +512,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(jvm_buffer_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='used - {{$view}}'),
-            prometheus.target('sum(jvm_buffer_total_capacity_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='capacity - {{$view}}'),
+            prometheus.target('sum(jvm_buffer_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='used - {{$view}}'),
+            prometheus.target('sum(jvm_buffer_total_capacity_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='capacity - {{$view}}'),
           ],
         );
 
@@ -525,7 +525,7 @@ local row = grafana.row;
           fill=2,
           min=0,
         )
-        .addTarget(prometheus.target('sum(jvm_buffer_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view) or sum(jvm_buffer_count_buffers{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='count - {{$view}}'));
+        .addTarget(prometheus.target('sum(jvm_buffer_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view) or sum(jvm_buffer_count_buffers{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", id="mapped"}) by ($view)', legendFormat='count - {{$view}}'));
 
       local templates =
         [
@@ -534,11 +534,11 @@ local row = grafana.row;
         + (if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.datasourceLogsTemplate()] else [])
         + [
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(jvm_memory_used_bytes{cluster=~"$cluster"}, job)'),
+          $.grafanaTemplates.jobTemplate('label_values(jvm_memory_used_bytes{cluster="$cluster"}, job)'),
           $.grafanaTemplates.viewByTemplate('pod,container'),
-          $.grafanaTemplates.namespaceTemplate('label_values(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
-          $.grafanaTemplates.containerTemplate('label_values(jvm_memory_used_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(jvm_memory_used_bytes{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.containerTemplate('label_values(jvm_memory_used_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
           memoryPoolsHeap,
           memoryPoolsNonHeap,
         ]

--- a/jsonnet/dashboards/apps/loki-distributed.libsonnet
+++ b/jsonnet/dashboards/apps/loki-distributed.libsonnet
@@ -36,7 +36,7 @@ local statPanel = grafana.statPanel;
         )
         .addTarget(
           prometheus.target(
-            expr='histogram_quantile(0.95, sum(rate( %s {cluster=~"$cluster", job=~"$job"}[1m])) by (le,route))' % target,
+            expr='histogram_quantile(0.95, sum(rate( %s {cluster="$cluster", job=~"$job"}[1m])) by (le,route))' % target,
             legendFormat='{{route}}'
           )
         );
@@ -55,7 +55,7 @@ local statPanel = grafana.statPanel;
         )
         .addTarget(
           prometheus.target(
-            expr='histogram_quantile(0.95, sum(rate( %s {cluster=~"$cluster", job=~"$job"}[1m])) by (le))' % target,
+            expr='histogram_quantile(0.95, sum(rate( %s {cluster="$cluster", job=~"$job"}[1m])) by (le))' % target,
             legendFormat=legendFormat
           )
         );
@@ -72,7 +72,7 @@ local statPanel = grafana.statPanel;
           linewidth=2,
           legend_sort='current'
         )
-        .addTarget(prometheus.target('%s{cluster=~"$cluster", job=~"$job"}' % target));
+        .addTarget(prometheus.target('%s{cluster="$cluster", job=~"$job"}' % target));
 
       /*Overview*/
       local version =
@@ -87,7 +87,7 @@ local statPanel = grafana.statPanel;
         .addTarget(
           prometheus.target(
             format='table',
-            expr='loki_build_info{cluster=~"$cluster", job=~"$job"}'
+            expr='loki_build_info{cluster="$cluster", job=~"$job"}'
           )
         );
       local msgs =
@@ -99,7 +99,7 @@ local statPanel = grafana.statPanel;
           unit='short',
         )
         .addTarget(
-          prometheus.target('sum(log_messages_total{cluster=~"$cluster", job=~"$job"})')
+          prometheus.target('sum(log_messages_total{cluster="$cluster", job=~"$job"})')
         );
 
       local errors =
@@ -110,7 +110,7 @@ local statPanel = grafana.statPanel;
           reducerFunction='last',
           colorMode='background',
         )
-        .addTarget(prometheus.target('sum(log_messages_total{cluster=~"$cluster", job=~"$job",level="error"})'))
+        .addTarget(prometheus.target('sum(log_messages_total{cluster="$cluster", job=~"$job",level="error"})'))
         .addThreshold({ value: 0, color: 'green' })
         .addThreshold({ value: 1, color: 'orange' });
 
@@ -122,7 +122,7 @@ local statPanel = grafana.statPanel;
           reducerFunction='last',
           colorMode='background',
         )
-        .addTarget(prometheus.target(format='table', instant=false, expr='loki_panic_total{cluster=~"$cluster", job=~"$job"}'))
+        .addTarget(prometheus.target(format='table', instant=false, expr='loki_panic_total{cluster="$cluster", job=~"$job"}'))
         .addThreshold({ value: 0, color: 'green' })
         .addThreshold({ value: 1, color: 'red' });
 
@@ -142,7 +142,7 @@ local statPanel = grafana.statPanel;
         )
         .addTarget(
           prometheus.target(
-            expr='sum(irate(log_messages_total{cluster=~"$cluster", job=~"$job"}[1m])) by (level)',
+            expr='sum(irate(log_messages_total{cluster="$cluster", job=~"$job"}[1m])) by (level)',
             legendFormat='{{operation}}'
           )
         );
@@ -160,7 +160,7 @@ local statPanel = grafana.statPanel;
         )
         .addTarget(
           prometheus.target(
-            expr='histogram_quantile(0.95, sum(rate(loki_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job"}[5m])) by (le,route))',
+            expr='histogram_quantile(0.95, sum(rate(loki_request_duration_seconds_bucket{cluster="$cluster", job=~"$job"}[5m])) by (le,route))',
             legendFormat='{{route}}'
           )
         );
@@ -236,7 +236,7 @@ local statPanel = grafana.statPanel;
         )
         .addTarget(
           prometheus.target(
-            expr='histogram_quantile(0.95, sum(rate(loki_cache_value_size_bytes_bucket{cluster=~"$cluster", job=~"$job"}[5m])) by (le,name,method))',
+            expr='histogram_quantile(0.95, sum(rate(loki_cache_value_size_bytes_bucket{cluster="$cluster", job=~"$job"}[5m])) by (le,name,method))',
             legendFormat='{{name}} / {{method}}'
           )
         );
@@ -249,7 +249,7 @@ local statPanel = grafana.statPanel;
           fill=1,
           linewidth=1,
         )
-        .addTarget(prometheus.target(expr='loki_cache_fetched_keys{cluster=~"$cluster", job=~"$job"}', legendFormat='{{container}}/{{name}}'));
+        .addTarget(prometheus.target(expr='loki_cache_fetched_keys{cluster="$cluster", job=~"$job"}', legendFormat='{{container}}/{{name}}'));
 
       local cache_hits_keys =
         graphPanel.new(
@@ -259,7 +259,7 @@ local statPanel = grafana.statPanel;
           fill=1,
           linewidth=1,
         )
-        .addTarget(prometheus.target(expr='rate(loki_cache_hits{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='{{container}}/{{name}}'));
+        .addTarget(prometheus.target(expr='rate(loki_cache_hits{cluster="$cluster", job=~"$job"}[5m])', legendFormat='{{container}}/{{name}}'));
 
       /*Querrier*/
       local querier_cache_corruptions =
@@ -352,7 +352,7 @@ local statPanel = grafana.statPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(loki_build_info{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(loki_build_info{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/mysql-exporter.libsonnet
+++ b/jsonnet/dashboards/apps/mysql-exporter.libsonnet
@@ -41,7 +41,7 @@ local row = grafana.row;
             { color: $._config.grafanaDashboards.color.green, value: 3600 },
           ]
         )
-        .addTarget(prometheus.target('avg(mysql_global_status_uptime{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('avg(mysql_global_status_uptime{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='{{instance}}'));
 
       local currentQPS =
         statPanel.new(
@@ -58,7 +58,7 @@ local row = grafana.row;
             { color: $._config.grafanaDashboards.color.green, value: 75 },
           ]
         )
-        .addTarget(prometheus.target('avg(rate(mysql_global_status_queries{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('avg(rate(mysql_global_status_queries{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='{{instance}}'));
 
       local innoDBBufferPool =
         statPanel.new(
@@ -76,7 +76,7 @@ local row = grafana.row;
             { color: $._config.grafanaDashboards.color.green, value: 95 },
           ]
         )
-        .addTarget(prometheus.target('avg(mysql_global_variables_innodb_buffer_pool_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('avg(mysql_global_variables_innodb_buffer_pool_size{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='{{instance}}'));
 
       local mysqlConnections =
         graphPanel.new(
@@ -95,9 +95,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'Max Connections', fill: 0 })
         .addTargets(
           [
-            prometheus.target('sum(max_over_time(mysql_global_status_threads_connected{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Connections'),
-            prometheus.target('sum(mysql_global_status_max_used_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Max Used Connections'),
-            prometheus.target('sum(mysql_global_variables_max_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Max Connections'),
+            prometheus.target('sum(max_over_time(mysql_global_status_threads_connected{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Connections'),
+            prometheus.target('sum(mysql_global_status_max_used_connections{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Max Used Connections'),
+            prometheus.target('sum(mysql_global_variables_max_connections{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Max Connections'),
           ]
         );
 
@@ -120,9 +120,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'Avg Threads Running', color: $._config.grafanaDashboards.color.yellow })
         .addTargets(
           [
-            prometheus.target('sum(max_over_time(mysql_global_status_threads_connected{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Peak Threads Connected'),
-            prometheus.target('sum(max_over_time(mysql_global_status_threads_running{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Peak Threads Running'),
-            prometheus.target('sum(avg_over_time(mysql_global_status_threads_running{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Avg Threads Running'),
+            prometheus.target('sum(max_over_time(mysql_global_status_threads_connected{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Peak Threads Connected'),
+            prometheus.target('sum(max_over_time(mysql_global_status_threads_running{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Peak Threads Running'),
+            prometheus.target('sum(avg_over_time(mysql_global_status_threads_running{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Avg Threads Running'),
           ]
         );
 
@@ -143,7 +143,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(rate(mysql_global_status_questions{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='{{instance}}'),
+            prometheus.target('avg(rate(mysql_global_status_questions{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='{{instance}}'),
           ]
         );
 
@@ -165,9 +165,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'Threads Created', fill: 0 })
         .addTargets(
           [
-            prometheus.target('sum(mysql_global_variables_thread_cache_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Thread Cache Size'),
-            prometheus.target('sum(mysql_global_status_threads_cached{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Threads Cached'),
-            prometheus.target('sum(rate(mysql_global_status_threads_created{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Threads Created'),
+            prometheus.target('sum(mysql_global_variables_thread_cache_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Thread Cache Size'),
+            prometheus.target('sum(mysql_global_status_threads_cached{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Threads Cached'),
+            prometheus.target('sum(rate(mysql_global_status_threads_created{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Threads Created'),
           ]
         );
 
@@ -187,9 +187,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_created_tmp_tables{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Tables'),
-            prometheus.target('sum(rate(mysql_global_status_created_tmp_disk_tables{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Disk Tables'),
-            prometheus.target('sum(rate(mysql_global_status_created_tmp_files{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Files'),
+            prometheus.target('sum(rate(mysql_global_status_created_tmp_tables{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Tables'),
+            prometheus.target('sum(rate(mysql_global_status_created_tmp_disk_tables{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Disk Tables'),
+            prometheus.target('sum(rate(mysql_global_status_created_tmp_files{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Created Tmp Files'),
           ]
         );
 
@@ -210,11 +210,11 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_select_full_range_join{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Full Join'),
-            prometheus.target('sum(rate(mysql_global_status_select_range{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Full Range Join'),
-            prometheus.target('sum(rate(mysql_global_status_select_range_check{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Range'),
-            prometheus.target('sum(rate(mysql_global_status_select_range_check{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Range Check'),
-            prometheus.target('sum(rate(mysql_global_status_select_scan{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Scan'),
+            prometheus.target('sum(rate(mysql_global_status_select_full_range_join{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Full Join'),
+            prometheus.target('sum(rate(mysql_global_status_select_range{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Full Range Join'),
+            prometheus.target('sum(rate(mysql_global_status_select_range_check{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Range'),
+            prometheus.target('sum(rate(mysql_global_status_select_range_check{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Range Check'),
+            prometheus.target('sum(rate(mysql_global_status_select_scan{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Select Scan'),
           ]
         );
 
@@ -235,10 +235,10 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_sort_rows{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Rows'),
-            prometheus.target('sum(rate(mysql_global_status_sort_range{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Range'),
-            prometheus.target('sum(rate(mysql_global_status_sort_merge_passes{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Merge Passes'),
-            prometheus.target('sum(rate(mysql_global_status_sort_scan{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Scan'),
+            prometheus.target('sum(rate(mysql_global_status_sort_rows{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Rows'),
+            prometheus.target('sum(rate(mysql_global_status_sort_range{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Range'),
+            prometheus.target('sum(rate(mysql_global_status_sort_merge_passes{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Merge Passes'),
+            prometheus.target('sum(rate(mysql_global_status_sort_scan{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Sort Scan'),
           ]
         );
 
@@ -259,7 +259,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_slow_queries{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Slow Queries'),
+            prometheus.target('sum(rate(mysql_global_status_slow_queries{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Slow Queries'),
           ]
         );
 
@@ -280,8 +280,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_aborted_connects{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Aborted Connects (attempts)'),
-            prometheus.target('sum(rate(mysql_global_status_aborted_clients{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Aborted Clients (timeout)'),
+            prometheus.target('sum(rate(mysql_global_status_aborted_connects{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Aborted Connects (attempts)'),
+            prometheus.target('sum(rate(mysql_global_status_aborted_clients{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Aborted Clients (timeout)'),
           ]
         );
 
@@ -302,8 +302,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_table_locks_immediate{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Table Locks Immediate'),
-            prometheus.target('sum(rate(mysql_global_status_table_locks_waited{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Table Locks Waited'),
+            prometheus.target('sum(rate(mysql_global_status_table_locks_immediate{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Table Locks Immediate'),
+            prometheus.target('sum(rate(mysql_global_status_table_locks_waited{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Table Locks Waited'),
           ]
         );
 
@@ -325,8 +325,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(mysql_global_status_bytes_received{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Inbound'),
-            prometheus.target('sum(rate(mysql_global_status_bytes_sent{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Outbound'),
+            prometheus.target('sum(rate(mysql_global_status_bytes_received{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Inbound'),
+            prometheus.target('sum(rate(mysql_global_status_bytes_sent{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m]))', legendFormat='Outbound'),
           ]
         );
 
@@ -348,14 +348,14 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(mysql_global_status_innodb_page_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"} * on (instance) group_left() avg(mysql_global_status_buffer_pool_pages{cluster=~"$cluster", job=~"$job", instance=~"$instance", state="data"}) by (instance))', legendFormat='InnoDB Buffer Pool Data'),
-            prometheus.target('sum(mysql_global_variables_innodb_log_buffer_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Log Buffer Size'),
-            prometheus.target('sum(mysql_global_variables_innodb_additional_mem_pool_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Additional Memory Pool Size'),
-            prometheus.target('sum(mysql_global_status_innodb_mem_dictionary{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Dictionary Size'),
-            prometheus.target('sum(mysql_global_variables_key_buffer_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Key Buffer Size'),
-            prometheus.target('sum(mysql_global_variables_query_cache_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Query Cache Size'),
-            prometheus.target('sum(mysql_global_status_innodb_mem_adaptive_hash{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Adaptive Hash Index Size'),
-            prometheus.target('sum(mysql_global_variables_tokudb_cache_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', legendFormat='TokuDB Cache Size'),
+            prometheus.target('sum(mysql_global_status_innodb_page_size{cluster="$cluster", job=~"$job", instance=~"$instance"} * on (instance) group_left() avg(mysql_global_status_buffer_pool_pages{cluster="$cluster", job=~"$job", instance=~"$instance", state="data"}) by (instance))', legendFormat='InnoDB Buffer Pool Data'),
+            prometheus.target('sum(mysql_global_variables_innodb_log_buffer_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Log Buffer Size'),
+            prometheus.target('sum(mysql_global_variables_innodb_additional_mem_pool_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Additional Memory Pool Size'),
+            prometheus.target('sum(mysql_global_status_innodb_mem_dictionary{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='InnoDB Dictionary Size'),
+            prometheus.target('sum(mysql_global_variables_key_buffer_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Key Buffer Size'),
+            prometheus.target('sum(mysql_global_variables_query_cache_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Query Cache Size'),
+            prometheus.target('sum(mysql_global_status_innodb_mem_adaptive_hash{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='Adaptive Hash Index Size'),
+            prometheus.target('sum(mysql_global_variables_tokudb_cache_size{cluster="$cluster", job=~"$job", instance=~"$instance"})', legendFormat='TokuDB Cache Size'),
           ]
         );
 
@@ -376,7 +376,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('topk(5, rate(mysql_global_status_commands_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])>0)', legendFormat='Com_{{ command }}'),
+            prometheus.target('topk(5, rate(mysql_global_status_commands_total{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])>0)', legendFormat='Com_{{ command }}'),
           ]
         );
 
@@ -435,7 +435,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('mysql_info_schema_threads{cluster=~"$cluster", job=~"$job", instance=~"$instance"}', legendFormat='{{ state }}'),
+            prometheus.target('mysql_info_schema_threads{cluster="$cluster", job=~"$job", instance=~"$instance"}', legendFormat='{{ state }}'),
           ]
         );
 
@@ -454,7 +454,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('topk(5, avg_over_time(mysql_info_schema_threads{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1h]))', legendFormat='{{ state }}'),
+            prometheus.target('topk(5, avg_over_time(mysql_info_schema_threads{cluster="$cluster", job=~"$job", instance=~"$instance"}[1h]))', legendFormat='{{ state }}'),
           ]
         );
 
@@ -474,8 +474,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(mysql_global_status_qcache_free_memory{cluster=~"$cluster", job=~"$job", instance=~"$instance"} by (instance)', legendFormat='Free Memory'),
-            prometheus.target('avg(mysql_global_variables_query_cache_size{cluster=~"$cluster", job=~"$job", instance=~"$instance"} by (instance)', legendFormat='Query Cache Size'),
+            prometheus.target('avg(mysql_global_status_qcache_free_memory{cluster="$cluster", job=~"$job", instance=~"$instance"} by (instance)', legendFormat='Free Memory'),
+            prometheus.target('avg(mysql_global_variables_query_cache_size{cluster="$cluster", job=~"$job", instance=~"$instance"} by (instance)', legendFormat='Query Cache Size'),
           ]
         );
 
@@ -495,11 +495,11 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(rate(mysql_global_status_qcache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Hits'),
-            prometheus.target('avg(rate(mysql_global_status_qcache_inserts{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_inserts{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Inserts'),
-            prometheus.target('avg(rate(mysql_global_status_qcache_not_cached{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_not_cached{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Not Cached'),
-            prometheus.target('avg(rate(mysql_global_status_qcache_lowmem_prunes{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_lowmem_prunes{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Prunes'),
-            prometheus.target('avg(mysql_global_status_qcache_queries_in_cache{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Queries in Cache'),
+            prometheus.target('avg(rate(mysql_global_status_qcache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Hits'),
+            prometheus.target('avg(rate(mysql_global_status_qcache_inserts{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_inserts{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Inserts'),
+            prometheus.target('avg(rate(mysql_global_status_qcache_not_cached{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_not_cached{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Not Cached'),
+            prometheus.target('avg(rate(mysql_global_status_qcache_lowmem_prunes{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_qcache_lowmem_prunes{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Prunes'),
+            prometheus.target('avg(mysql_global_status_qcache_queries_in_cache{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Queries in Cache'),
           ]
         );
 
@@ -519,7 +519,7 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(rate(mysql_global_status_opened_files{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_files{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Openings'),
+            prometheus.target('avg(rate(mysql_global_status_opened_files{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_files{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Openings'),
           ]
         );
 
@@ -539,9 +539,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(mysql_global_status_open_files{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Files'),
-            prometheus.target('avg(mysql_global_variables_open_files_limit{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Files Limit'),
-            prometheus.target('avg(mysql_global_status_innodb_num_open_files{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='InnoDB Open Files'),
+            prometheus.target('avg(mysql_global_status_open_files{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Files'),
+            prometheus.target('avg(mysql_global_variables_open_files_limit{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Files Limit'),
+            prometheus.target('avg(mysql_global_status_innodb_num_open_files{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='InnoDB Open Files'),
           ]
         );
 
@@ -564,11 +564,11 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'Table Open Cache Hit Ratio', yaxis: 2 })
         .addTargets(
           [
-            prometheus.target('avg(rate(mysql_global_status_opened_tables{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_tables{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Openings'),
-            prometheus.target('avg(rate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Hits'),
-            prometheus.target('avg(rate(mysql_global_status_table_open_cache_misses{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_misses{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Misses'),
-            prometheus.target('avg(rate(mysql_global_status_table_open_cache_overflows{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_overflows{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Misses due to Overflows'),
-            prometheus.target('(avg(rate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance))/((avg(rate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance))+(avg(rate(mysql_global_status_table_open_cache_misses{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_misses{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)))', legendFormat='Table Open Cache Hit Ratio'),
+            prometheus.target('avg(rate(mysql_global_status_opened_tables{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_tables{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Openings'),
+            prometheus.target('avg(rate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Hits'),
+            prometheus.target('avg(rate(mysql_global_status_table_open_cache_misses{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_misses{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Misses'),
+            prometheus.target('avg(rate(mysql_global_status_table_open_cache_overflows{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_overflows{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Misses due to Overflows'),
+            prometheus.target('(avg(rate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance))/((avg(rate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_hits{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance))+(avg(rate(mysql_global_status_table_open_cache_misses{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_table_open_cache_misses{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)))', legendFormat='Table Open Cache Hit Ratio'),
           ]
         );
 
@@ -589,8 +589,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('avg(mysql_global_status_open_tables{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Tables'),
-            prometheus.target('avg(mysql_global_variables_table_open_cache{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Table Open Cache'),
+            prometheus.target('avg(mysql_global_status_open_tables{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Tables'),
+            prometheus.target('avg(mysql_global_variables_table_open_cache{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Table Open Cache'),
           ]
         );
 
@@ -612,9 +612,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'Opened Table Definitions', yaxis: 2 })
         .addTargets(
           [
-            prometheus.target('avg(mysql_global_status_open_table_definitions{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Table Definitions'),
-            prometheus.target('avg(mysql_global_variables_table_definition_cache{cluster=~"$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Table Definitions Cache Size'),
-            prometheus.target('avg(rate(mysql_global_status_opened_table_definitions{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_table_definitions{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Opened Table Definitions'),
+            prometheus.target('avg(mysql_global_status_open_table_definitions{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Open Table Definitions'),
+            prometheus.target('avg(mysql_global_variables_table_definition_cache{cluster="$cluster", job=~"$job", instance=~"$instance"}) by (instance)', legendFormat='Table Definitions Cache Size'),
+            prometheus.target('avg(rate(mysql_global_status_opened_table_definitions{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance) or avg(irate(mysql_global_status_opened_table_definitions{cluster="$cluster", job=~"$job", instance=~"$instance"}[5m])) by (instance)', legendFormat='Opened Table Definitions'),
           ]
         );
 
@@ -622,8 +622,8 @@ local row = grafana.row;
         [
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(mysql_up, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(mysql_up{cluster=~"$cluster"}, job)'),
-          $.grafanaTemplates.instanceTemplate('label_values(mysql_up{cluster=~"$cluster", job=~"$job"}, instance)'),
+          $.grafanaTemplates.jobTemplate('label_values(mysql_up{cluster="$cluster"}, job)'),
+          $.grafanaTemplates.instanceTemplate('label_values(mysql_up{cluster="$cluster", job=~"$job"}, instance)'),
         ];
 
       dashboard.new(

--- a/jsonnet/dashboards/apps/nginx-ingress.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-ingress.libsonnet
@@ -33,7 +33,7 @@ local table = grafana.tablePanel;
           name='ingress',
           label='Ingress',
           datasource='$datasource',
-          query='label_values(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, ingress)',
+          query='label_values(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, ingress)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -55,9 +55,9 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -76,9 +76,9 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -96,8 +96,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -115,8 +115,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -136,7 +136,7 @@ local table = grafana.tablePanel;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
 
       local logs =
         logPanel.new(
@@ -144,7 +144,7 @@ local table = grafana.tablePanel;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
 
       local controllerRequestVolume =
         statPanel.new(
@@ -152,7 +152,7 @@ local table = grafana.tablePanel;
           datasource='$datasource',
           unit='reqps',
         )
-        .addTarget(prometheus.target('round(sum(irate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod", namespace=~"$namespace", container=~"$container"}[5m])), 0.001)'));
+        .addTarget(prometheus.target('round(sum(irate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod", namespace=~"$namespace", container=~"$container"}[5m])), 0.001)'));
 
       local configReloads =
         statPanel.new(
@@ -160,7 +160,7 @@ local table = grafana.tablePanel;
           datasource='$datasource',
           decimals=0,
         )
-        .addTarget(prometheus.target('avg(nginx_ingress_controller_success{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", container=~"$container"})'));
+        .addTarget(prometheus.target('avg(nginx_ingress_controller_success{cluster="$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", container=~"$container"})'));
 
       local ingressRequestVolume =
         graphPanel.new(
@@ -177,14 +177,14 @@ local table = grafana.tablePanel;
           legend_avg=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('round(sum(irate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", ingress=~"$ingress", container=~"$container"}[5m])) by (ingress), 0.001)', legendFormat='{{ingress}}'));
+        .addTarget(prometheus.target('round(sum(irate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", ingress=~"$ingress", container=~"$container"}[5m])) by (ingress), 0.001)', legendFormat='{{ingress}}'));
 
       local controllerConnections =
         statPanel.new(
           title='Controller Connections',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", container=~"$container"}[5m]))'));
+        .addTarget(prometheus.target('sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{cluster="$cluster", job=~"$job", controller_pod=~"$pod", controller_namespace=~"$namespace", container=~"$container"}[5m]))'));
 
       local configFailed =
         statPanel.new(
@@ -192,7 +192,7 @@ local table = grafana.tablePanel;
           datasource='$datasource',
           noValue='0',
         )
-        .addTarget(prometheus.target('count(nginx_ingress_controller_config_last_reload_successful{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod",controller_namespace=~"$namespace", container=~"$container"} == 0)'));
+        .addTarget(prometheus.target('count(nginx_ingress_controller_config_last_reload_successful{cluster="$cluster", job=~"$job", controller_pod=~"$pod",controller_namespace=~"$namespace", container=~"$container"} == 0)'));
 
       local controllerSuccessRate =
         statPanel.new(
@@ -208,7 +208,7 @@ local table = grafana.tablePanel;
             { color: $._config.grafanaDashboards.color.green, value: 90 },
           ]
         )
-        .addTarget(prometheus.target('sum(rate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",status!~"[4-5].*", container=~"$container"}[5m])) / sum(rate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod", namespace=~"$namespace", container=~"$container"}[5m])) * 100'));
+        .addTarget(prometheus.target('sum(rate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",status!~"[4-5].*", container=~"$container"}[5m])) / sum(rate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod", namespace=~"$namespace", container=~"$container"}[5m])) * 100'));
 
       local ingressSuccessRate =
         graphPanel.new(
@@ -227,7 +227,7 @@ local table = grafana.tablePanel;
           legend_min=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('sum(rate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",ingress=~"$ingress",status!~"[4-5].*",  container=~"$container"}[5m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{cluster=~"$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",  container=~"$container", ingress=~"$ingress"}[5m])) by (ingress)', legendFormat='{{ingress}}'));
+        .addTarget(prometheus.target('sum(rate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",ingress=~"$ingress",status!~"[4-5].*",  container=~"$container"}[5m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{cluster="$cluster", job=~"$job", controller_pod=~"$pod",namespace=~"$namespace",  container=~"$container", ingress=~"$ingress"}[5m])) by (ingress)', legendFormat='{{ingress}}'));
 
       local percentileTable =
         table.new(
@@ -246,11 +246,11 @@ local table = grafana.tablePanel;
         )
         .addTargets(
           [
-            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
-            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
-            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
-            prometheus.target(format='table', instant=true, expr='sum(irate(nginx_ingress_controller_request_size_sum{cluster=~"$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (ingress)'),
-            prometheus.target(format='table', instant=true, expr='sum(irate(nginx_ingress_controller_response_size_sum{cluster=~"$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (ingress)'),
+            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
+            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
+            prometheus.target(format='table', instant=true, expr='histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (le, ingress))'),
+            prometheus.target(format='table', instant=true, expr='sum(irate(nginx_ingress_controller_request_size_sum{cluster="$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (ingress)'),
+            prometheus.target(format='table', instant=true, expr='sum(irate(nginx_ingress_controller_response_size_sum{cluster="$cluster", job=~"$job", ingress!="", controller_pod=~"$pod",  container=~"$container", controller_namespace=~"$namespace", ingress=~"$ingress"}[5m])) by (ingress)'),
           ]
         );
 
@@ -267,7 +267,7 @@ local table = grafana.tablePanel;
             { alias: 'TTL', pattern: 'Value', type: 'number', colors: colors, colorMode: 'cell', thresholds: [0, 8 * 24 * 60 * 60], unit: 's', decimals: 0 },
           ]
         )
-        .addTarget(prometheus.target(format='table', instant=true, expr='avg(nginx_ingress_controller_ssl_expire_time_seconds{cluster=~"$cluster", job=~"$job", pod=~"$pod", namespace=~"$namespace", container=~"$container"}) by (host) - time()'));
+        .addTarget(prometheus.target(format='table', instant=true, expr='avg(nginx_ingress_controller_ssl_expire_time_seconds{cluster="$cluster", job=~"$job", pod=~"$pod", namespace=~"$namespace", container=~"$container"}) by (host) - time()'));
 
       local templates =
         [
@@ -276,11 +276,11 @@ local table = grafana.tablePanel;
         + (if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.datasourceLogsTemplate()] else [])
         + [
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(nginx_ingress_controller_config_hash{cluster=~"$cluster"}, job)'),
+          $.grafanaTemplates.jobTemplate('label_values(nginx_ingress_controller_config_hash{cluster="$cluster"}, job)'),
           $.grafanaTemplates.viewByTemplate('pod,container'),
-          $.grafanaTemplates.namespaceTemplate('label_values(nginx_ingress_controller_config_hash{cluster=~"$cluster", job=~"$job"}, controller_namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(nginx_ingress_controller_config_hash{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
-          $.grafanaTemplates.containerTemplate('label_values(nginx_ingress_controller_config_hash{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(nginx_ingress_controller_config_hash{cluster="$cluster", job=~"$job"}, controller_namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(nginx_ingress_controller_config_hash{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.containerTemplate('label_values(nginx_ingress_controller_config_hash{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
           ingressTemplate,
         ]
         + if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.searchTemplate()] else [];

--- a/jsonnet/dashboards/apps/nginx-nrpe.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-nrpe.libsonnet
@@ -32,9 +32,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(nginx_accepts_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='accepts'),
-            prometheus.target('rate(nginx_handled_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='handled'),
-            prometheus.target('rate(nginx_active{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='active'),
+            prometheus.target('rate(nginx_accepts_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='accepts'),
+            prometheus.target('rate(nginx_handled_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='handled'),
+            prometheus.target('rate(nginx_active{cluster="$cluster", job=~"$job"}[5m])', legendFormat='active'),
           ],
         );
 
@@ -47,9 +47,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(nginx_reading{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='reading'),
-            prometheus.target('rate(nginx_writing{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='writing'),
-            prometheus.target('rate(nginx_waiting{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='waiting'),
+            prometheus.target('rate(nginx_reading{cluster="$cluster", job=~"$job"}[5m])', legendFormat='reading'),
+            prometheus.target('rate(nginx_writing{cluster="$cluster", job=~"$job"}[5m])', legendFormat='writing'),
+            prometheus.target('rate(nginx_waiting{cluster="$cluster", job=~"$job"}[5m])', legendFormat='waiting'),
           ],
         );
 
@@ -60,7 +60,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(nginx_requests_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='requests'));
+        .addTarget(prometheus.target('rate(nginx_requests_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='requests'));
 
       local panels = [
         row.new('Connections') { gridPos: { x: 0, y: 0, w: 24, h: 1 } },
@@ -82,7 +82,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(nginx_accepts_total{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(nginx_accepts_total{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/nginx-vts-enhanced-legacy.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-vts-enhanced-legacy.libsonnet
@@ -31,7 +31,7 @@ local row = grafana.row;
           name='host',
           label='Host',
           datasource='$datasource',
-          query='label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
+          query='label_values(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -43,7 +43,7 @@ local row = grafana.row;
           name='upstream',
           label='Upstream',
           datasource='$datasource',
-          query='label_values(nginx_upstream_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, upstream)',
+          query='label_values(nginx_upstream_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, upstream)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -65,9 +65,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodRequests'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodLimits'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodRequests'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodLimits'),
           ],
         );
 
@@ -86,9 +86,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodRequests - {{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodLimits - {{container}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodRequests - {{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodLimits - {{container}}'),
           ],
         );
 
@@ -106,8 +106,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -125,8 +125,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -146,7 +146,7 @@ local row = grafana.row;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"[10s])) by (pod)', legendFormat='{{pod}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"[10s])) by (pod)', legendFormat='{{pod}}'));
 
       local logs =
         logPanel.new(
@@ -154,14 +154,14 @@ local row = grafana.row;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"'));
 
       local serverConnections =
         graphPanel.new(
           title='Server Connections',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_server_connections{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(nginx_server_connections{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
 
       local serverCache =
         graphPanel.new(
@@ -169,14 +169,14 @@ local row = grafana.row;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_server_cache{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_server_cache{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (status)', legendFormat='{{status}}'));
 
       local serverRequests =
         graphPanel.new(
           title='Server Requests',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(irate(nginx_server_requests{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_server_requests{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local serverBytes =
         graphPanel.new(
@@ -185,7 +185,7 @@ local row = grafana.row;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local upstreamRequests =
         graphPanel.new(
@@ -193,7 +193,7 @@ local row = grafana.row;
           datasource='$datasource',
           description="This one is providing aggregated error codes, but it's still possible to graph these per upstream.",
         )
-        .addTarget(prometheus.target('sum(irate(nginx_upstream_requests{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_upstream_requests{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local upstreamBytes =
         graphPanel.new(
@@ -202,14 +202,14 @@ local row = grafana.row;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_upstream_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_upstream_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local upstreamBackendResponse =
         graphPanel.new(
           title='Upstream Backend Response',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_upstream_responseMsec{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}) by (backend)', legendFormat='{{backend}}'));
+        .addTarget(prometheus.target('sum(nginx_upstream_responseMsec{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}) by (backend)', legendFormat='{{backend}}'));
 
       local templates =
         [
@@ -218,9 +218,9 @@ local row = grafana.row;
         + (if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.datasourceLogsTemplate()] else [])
         + [
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(nginx_server_bytes{cluster=~"$cluster"}, job)'),
-          $.grafanaTemplates.namespaceTemplate('label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.jobTemplate('label_values(nginx_server_bytes{cluster="$cluster"}, job)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(nginx_server_bytes{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
           hostTemplate,
           upstreamTemplate,
         ]

--- a/jsonnet/dashboards/apps/nginx-vts-enhanced.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-vts-enhanced.libsonnet
@@ -31,7 +31,7 @@ local row = grafana.row;
           name='host',
           label='Host',
           datasource='$datasource',
-          query='label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
+          query='label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -43,7 +43,7 @@ local row = grafana.row;
           name='upstream',
           label='Upstream',
           datasource='$datasource',
-          query='label_values(nginx_vts_upstream_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, upstream)',
+          query='label_values(nginx_vts_upstream_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, upstream)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -65,9 +65,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodRequests'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodLimits'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodRequests'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"})', legendFormat='PodLimits'),
           ],
         );
 
@@ -86,9 +86,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodRequests - {{container}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodLimits - {{container}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!~"POD|"}) by (container)', legendFormat='{{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodRequests - {{container}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}) by (container)', legendFormat='PodLimits - {{container}}'),
           ],
         );
 
@@ -106,8 +106,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -125,8 +125,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -146,7 +146,7 @@ local row = grafana.row;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"[10s])) by (pod)', legendFormat='{{pod}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"[10s])) by (pod)', legendFormat='{{pod}}'));
 
       local logs =
         logPanel.new(
@@ -154,14 +154,14 @@ local row = grafana.row;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"} |~ "(?i)$search"'));
 
       local serverConnections =
         graphPanel.new(
           title='Server Connections',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_vts_main_connections{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(nginx_vts_main_connections{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
 
       local serverCache =
         graphPanel.new(
@@ -169,14 +169,14 @@ local row = grafana.row;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_server_cache_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_server_cache_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (status)', legendFormat='{{status}}'));
 
       local serverRequests =
         graphPanel.new(
           title='Server Requests',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_server_requests_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_server_requests_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local serverBytes =
         graphPanel.new(
@@ -185,7 +185,7 @@ local row = grafana.row;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local upstreamRequests =
         graphPanel.new(
@@ -193,7 +193,7 @@ local row = grafana.row;
           datasource='$datasource',
           description="This one is providing aggregated error codes, but it's still possible to graph these per upstream.",
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_upstream_requests_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_upstream_requests_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local upstreamBytes =
         graphPanel.new(
@@ -202,14 +202,14 @@ local row = grafana.row;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_upstream_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_upstream_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local upstreamBackendResponse =
         graphPanel.new(
           title='Upstream Backend Response',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_vts_upstream_response_seconds{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}) by (backend)', legendFormat='{{backend}}'));
+        .addTarget(prometheus.target('sum(nginx_vts_upstream_response_seconds{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", upstream=~"^$upstream$"}) by (backend)', legendFormat='{{backend}}'));
 
       local templates =
         [
@@ -218,9 +218,9 @@ local row = grafana.row;
         + (if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.datasourceLogsTemplate()] else [])
         + [
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster"}, job)'),
-          $.grafanaTemplates.namespaceTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.jobTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster"}, job)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
           hostTemplate,
           upstreamTemplate,
         ]

--- a/jsonnet/dashboards/apps/nginx-vts-legacy.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-vts-legacy.libsonnet
@@ -28,7 +28,7 @@ local graphPanel = grafana.graphPanel;
           name='host',
           label='Host',
           datasource='$datasource',
-          query='label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
+          query='label_values(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -40,14 +40,14 @@ local graphPanel = grafana.graphPanel;
           title='Server Connections',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_server_connections{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(nginx_server_connections{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
 
       local serverRequests =
         graphPanel.new(
           title='Server Requests',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(irate(nginx_server_requests{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_server_requests{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local serverBytes =
         graphPanel.new(
@@ -56,15 +56,15 @@ local graphPanel = grafana.graphPanel;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local templates =
         [
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(nginx_server_bytes{cluster=~"$cluster"}, job)'),
-          $.grafanaTemplates.namespaceTemplate('label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(nginx_server_bytes{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.jobTemplate('label_values(nginx_server_bytes{cluster="$cluster"}, job)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(nginx_server_bytes{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(nginx_server_bytes{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
           hostTemplate,
         ];
 

--- a/jsonnet/dashboards/apps/nginx-vts.libsonnet
+++ b/jsonnet/dashboards/apps/nginx-vts.libsonnet
@@ -28,7 +28,7 @@ local graphPanel = grafana.graphPanel;
           name='host',
           label='Host',
           datasource='$datasource',
-          query='label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
+          query='label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod"}, host)',
           refresh=$._config.grafanaDashboards.templateRefresh,
           sort=$._config.grafanaDashboards.templateSort,
           includeAll=true,
@@ -40,14 +40,14 @@ local graphPanel = grafana.graphPanel;
           title='Server Connections',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(nginx_vts_main_connections{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
+        .addTarget(prometheus.target('sum(nginx_vts_main_connections{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", status=~"active|writing|reading|waiting"}) by (status)', legendFormat='{{status}}'));
 
       local serverRequests =
         graphPanel.new(
           title='Server Requests',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_server_requests_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_server_requests_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$", code!="total"}[5m])) by (code)', legendFormat='{{code}}'));
 
       local serverBytes =
         graphPanel.new(
@@ -56,15 +56,15 @@ local graphPanel = grafana.graphPanel;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('sum(irate(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
+        .addTarget(prometheus.target('sum(irate(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", host=~"^$host$"}[5m])) by (direction)', legendFormat='{{direction}}'));
 
       local templates =
         [
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster"}, job)'),
-          $.grafanaTemplates.namespaceTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(nginx_vts_server_bytes_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.jobTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster"}, job)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(nginx_vts_server_bytes_total{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
           hostTemplate,
         ];
 

--- a/jsonnet/dashboards/apps/php-fpm.libsonnet
+++ b/jsonnet/dashboards/apps/php-fpm.libsonnet
@@ -30,7 +30,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(fpm_accepted_conn_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='connections'));
+        .addTarget(prometheus.target('rate(fpm_accepted_conn_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='connections'));
 
       local slowRequests =
         graphPanel.new(
@@ -39,7 +39,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('rate(fpm_slow_requests_total{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='requests'));
+        .addTarget(prometheus.target('rate(fpm_slow_requests_total{cluster="$cluster", job=~"$job"}[5m])', legendFormat='requests'));
 
       local processes =
         graphPanel.new(
@@ -48,10 +48,10 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(fpm_max_active_processes{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='max active processes'),
-            prometheus.target('rate(fpm_active_processes{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='active processes'),
-            prometheus.target('rate(fpm_total_processes{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='total processes'),
-            prometheus.target('rate(fpm_idle_processes{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='idle processes'),
+            prometheus.target('rate(fpm_max_active_processes{cluster="$cluster", job=~"$job"}[5m])', legendFormat='max active processes'),
+            prometheus.target('rate(fpm_active_processes{cluster="$cluster", job=~"$job"}[5m])', legendFormat='active processes'),
+            prometheus.target('rate(fpm_total_processes{cluster="$cluster", job=~"$job"}[5m])', legendFormat='total processes'),
+            prometheus.target('rate(fpm_idle_processes{cluster="$cluster", job=~"$job"}[5m])', legendFormat='idle processes'),
           ],
         );
 
@@ -60,7 +60,7 @@ local row = grafana.row;
           title='PHP FPM max children processes reached',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('rate(fpm_max_children_reached{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='children processes'));
+        .addTarget(prometheus.target('rate(fpm_max_children_reached{cluster="$cluster", job=~"$job"}[5m])', legendFormat='children processes'));
 
       local listenQueue =
         graphPanel.new(
@@ -69,9 +69,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('rate(fpm_max_listen_queue{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='max listen queue'),
-            prometheus.target('rate(fpm_listen_queue{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='listen queue'),
-            prometheus.target('rate(fpm_listen_queue_len{cluster=~"$cluster", job=~"$job"}[5m])', legendFormat='listen queue len'),
+            prometheus.target('rate(fpm_max_listen_queue{cluster="$cluster", job=~"$job"}[5m])', legendFormat='max listen queue'),
+            prometheus.target('rate(fpm_listen_queue{cluster="$cluster", job=~"$job"}[5m])', legendFormat='listen queue'),
+            prometheus.target('rate(fpm_listen_queue_len{cluster="$cluster", job=~"$job"}[5m])', legendFormat='listen queue len'),
           ],
         );
 
@@ -99,7 +99,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(fpm_accepted_conn_total{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(fpm_accepted_conn_total{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/postfix.libsonnet
+++ b/jsonnet/dashboards/apps/postfix.libsonnet
@@ -30,7 +30,7 @@ local row = grafana.row;
           stack=true,
           nullPointMode='null as zero',
         )
-        .addTarget(prometheus.target('sum(postfix_size{cluster=~"$cluster", job=~"$job"})', legendFormat='queue size'));
+        .addTarget(prometheus.target('sum(postfix_size{cluster="$cluster", job=~"$job"})', legendFormat='queue size'));
 
       local panels = [
         row.new('Queue Size') { gridPos: { x: 0, y: 0, w: 24, h: 1 } },
@@ -49,7 +49,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(postfix_size{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(postfix_size{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/python-flask.libsonnet
+++ b/jsonnet/dashboards/apps/python-flask.libsonnet
@@ -40,9 +40,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -61,9 +61,9 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/PodLimits/', color: $._config.grafanaDashboards.color.orange, dashes: true, fill: 0, stack: false, hideTooltip: true })
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", id!="", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(\nkube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)\n', legendFormat='PodLimits - {{$view}}'),
           ],
         );
 
@@ -81,8 +81,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -100,8 +100,8 @@ local row = grafana.row;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ],
         );
 
@@ -121,7 +121,7 @@ local row = grafana.row;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
 
       local logs =
         logPanel.new(
@@ -129,7 +129,7 @@ local row = grafana.row;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
 
       local requestPerMinute =
         graphPanel.new(
@@ -148,7 +148,7 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'HTTP 500', color: $._config.grafanaDashboards.color.red })
         .addTarget(
           prometheus.target(
-            'sum(increase(\n  flask_http_request_total{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m]\n) / 2) by (status, $view)',
+            'sum(increase(\n  flask_http_request_total{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container"}[1m]\n) / 2) by (status, $view)',
             legendFormat='HTTP {{status}} - {{$view}}',
           ),
         );
@@ -168,7 +168,7 @@ local row = grafana.row;
         .addSeriesOverride({ alias: 'errors', color: $._config.grafanaDashboards.color.orange })
         .addTarget(
           prometheus.target(
-            'sum(\n  rate(\n    flask_http_request_duration_seconds_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status!="200"}[1m]\n)\n) by (status, $view)',
+            'sum(\n  rate(\n    flask_http_request_duration_seconds_count{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status!="200"}[1m]\n)\n) by (status, $view)',
             legendFormat='HTTP {{status}} - {{$view}}',
           ),
         );
@@ -189,7 +189,7 @@ local row = grafana.row;
           legend_sort='avg',
           legend_sortDesc=true,
         )
-        .addTarget(prometheus.target('avg(rate(\n  flask_http_request_duration_seconds_sum{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n)\n /\nrate(\n  flask_http_request_duration_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n) >= 0)  by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
+        .addTarget(prometheus.target('avg(rate(\n  flask_http_request_duration_seconds_sum{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n)\n /\nrate(\n  flask_http_request_duration_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n) >= 0)  by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
 
       local requestUnder =
         graphPanel.new(
@@ -207,7 +207,7 @@ local row = grafana.row;
           legend_sort='avg',
           legend_sortDesc=true,
         )
-        .addTarget(prometheus.target('sum(increase(\n  flask_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200",le="0.25"}[1m]\n)\n / ignoring (le)\nincrease(\n  flask_http_request_duration_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n) >= 0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
+        .addTarget(prometheus.target('sum(increase(\n  flask_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200",le="0.25"}[1m]\n)\n / ignoring (le)\nincrease(\n  flask_http_request_duration_seconds_count{job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n) >= 0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
 
       local requestDurationP50 =
         graphPanel.new(
@@ -225,7 +225,7 @@ local row = grafana.row;
           legend_sort='avg',
           legend_sortDesc=true,
         )
-        .addTarget(prometheus.target('avg(histogram_quantile(\n  0.5,\n  rate(\n    flask_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n  )\n)>=0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
+        .addTarget(prometheus.target('avg(histogram_quantile(\n  0.5,\n  rate(\n    flask_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n  )\n)>=0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
 
       local requestDurationP90 =
         graphPanel.new(
@@ -243,7 +243,7 @@ local row = grafana.row;
           legend_sort='avg',
           legend_sortDesc=true,
         )
-        .addTarget(prometheus.target('avg(histogram_quantile(\n  0.9,\n  rate(\n    flask_http_request_duration_seconds_bucket{cluster=~"$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n  )\n)>=0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
+        .addTarget(prometheus.target('avg(histogram_quantile(\n  0.9,\n  rate(\n    flask_http_request_duration_seconds_bucket{cluster="$cluster", job=~"$job", namespace=~"$namespace", pod=~"$pod", container=~"$container", status="200"}[1m]\n  )\n)>=0) by (status, $view)', legendFormat='HTTP 200 - {{$view}}'));
 
       local templates =
         [
@@ -252,11 +252,11 @@ local row = grafana.row;
         + (if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.datasourceLogsTemplate()] else [])
         + [
           $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-          $.grafanaTemplates.jobTemplate('label_values(flask_exporter_info{cluster=~"$cluster"}, job)'),
+          $.grafanaTemplates.jobTemplate('label_values(flask_exporter_info{cluster="$cluster"}, job)'),
           $.grafanaTemplates.viewByTemplate('pod,container'),
-          $.grafanaTemplates.namespaceTemplate('label_values(flask_exporter_info{cluster=~"$cluster", job=~"$job"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(flask_exporter_info{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
-          $.grafanaTemplates.containerTemplate('label_values(flask_exporter_info{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
+          $.grafanaTemplates.namespaceTemplate('label_values(flask_exporter_info{cluster="$cluster", job=~"$job"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(flask_exporter_info{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.containerTemplate('label_values(flask_exporter_info{cluster="$cluster", job=~"$job", namespace=~"$namespace"}, container)'),
         ]
         + if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.searchTemplate()] else [];
 

--- a/jsonnet/dashboards/apps/rabbitmq.libsonnet
+++ b/jsonnet/dashboards/apps/rabbitmq.libsonnet
@@ -30,8 +30,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(rabbitmq_deliver_total{cluster=~"$cluster", job=~"$job"}[5m]))', legendFormat='deliver'),
-            prometheus.target('sum(rate(rabbitmq_publish_total{cluster=~"$cluster", job=~"$job"}[5m]))', legendFormat='publish'),
+            prometheus.target('sum(rate(rabbitmq_deliver_total{cluster="$cluster", job=~"$job"}[5m]))', legendFormat='deliver'),
+            prometheus.target('sum(rate(rabbitmq_publish_total{cluster="$cluster", job=~"$job"}[5m]))', legendFormat='publish'),
           ],
         );
 
@@ -52,7 +52,7 @@ local row = grafana.row;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(rabbitmq_deliver_total{cluster=~"$cluster"}, job)'),
+        $.grafanaTemplates.jobTemplate('label_values(rabbitmq_deliver_total{cluster="$cluster"}, job)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/apps/ssl-exporter.libsonnet
+++ b/jsonnet/dashboards/apps/ssl-exporter.libsonnet
@@ -25,48 +25,41 @@ local statPanel = grafana.statPanel;
     'ssl-exporter':
       local totalUniqueCerts =
         statPanel.new(
-          title="Total Unique Certificates",
-          datasource="$datasource",
+          title='Total Unique Certificates',
+          datasource='$datasource',
           graphMode='none',
         )
         .addTarget(
           prometheus.target(
             format='table',
-            expr='count(max(ssl_cert_not_after{cluster=~"$cluster", job=~"$job"}) by (issuer_cn, serial_no))',
+            expr='count(max(ssl_cert_not_after{cluster="$cluster", job=~"$job"}) by (issuer_cn, serial_no))',
             instant=true,
           )
         );
 
       local totalProbeTargets =
         statPanel.new(
-          title="Total Probe Targets",
-          datasource="$datasource",
+          title='Total Probe Targets',
+          datasource='$datasource',
           graphMode='none',
         )
         .addTarget(
           prometheus.target(
             format='table',
-            expr='count(ssl_probe_success{cluster=~"$cluster"})',
+            expr='count(ssl_probe_success{cluster="$cluster"})',
             instant=true,
           )
         );
 
       local failedSSLCount =
         statPanel.new(
-          title="Expired/Failed Certificates",
-          datasource="$datasource",
+          title='Expired/Failed Certificates',
+          datasource='$datasource',
           graphMode='none',
         )
         .addTarget(
           prometheus.target(
-            expr='
-            (count(up{job=~"$job", cluster=~"$cluster"}==0) OR on() vector(0))+
-            (count(ssl_probe_success{cluster=~"$cluster"}==0) OR on() vector(0))+
-            (count((ssl_cert_not_after{cluster=~"$cluster"}-time())<0) OR on() vector(0))+
-            (count((ssl_file_not_after{cluster=~"$cluster"}-time())<0) OR on() vector(0))+
-            (count((ssl_kubeconfig_cert_not_after{cluster=~"$cluster"}-time())<0) OR on()vector(0))+
-            (count((ssl_kubernetes_cert_not_after{cluster=~"$cluster"}-time())<0) OR on()vector(0))
-            ',
+            expr='\n            (count(up{job=~"$job", cluster="$cluster"}==0) OR on() vector(0))+\n            (count(ssl_probe_success{cluster="$cluster"}==0) OR on() vector(0))+\n            (count((ssl_cert_not_after{cluster="$cluster"}-time())<0) OR on() vector(0))+\n            (count((ssl_file_not_after{cluster="$cluster"}-time())<0) OR on() vector(0))+\n            (count((ssl_kubeconfig_cert_not_after{cluster="$cluster"}-time())<0) OR on()vector(0))+\n            (count((ssl_kubernetes_cert_not_after{cluster="$cluster"}-time())<0) OR on()vector(0))\n            ',
             format='table',
             instant=true,
           )
@@ -76,17 +69,12 @@ local statPanel = grafana.statPanel;
 
       local nearingExpiryCount =
         statPanel.new(
-          title="Certificates Nearing Expiration",
-          datasource="$datasource",
+          title='Certificates Nearing Expiration',
+          datasource='$datasource',
           graphMode='none',
         ).addTarget(
           prometheus.target(
-            expr='
-            (count(0<(ssl_cert_not_after{cluster=~"$cluster"}-time())<8*24*60*60) OR on() vector(0))+
-            (count(0<(ssl_file_not_after{cluster=~"$cluster"}-time())<8*24*60*60) OR on() vector(0))+
-            (count(0<(ssl_kubeconfig_cert_not_after{cluster=~"$cluster"}-time())<8*24*60*60) OR on() vector(0)) +
-            (count(0<(ssl_kubernetes_cert_not_after{cluster=~"$cluster"}-time())<8*24*60*60) OR on() vector(0))
-            ',
+            expr='\n            (count(0<(ssl_cert_not_after{cluster="$cluster"}-time())<8*24*60*60) OR on() vector(0))+\n            (count(0<(ssl_file_not_after{cluster="$cluster"}-time())<8*24*60*60) OR on() vector(0))+\n            (count(0<(ssl_kubeconfig_cert_not_after{cluster="$cluster"}-time())<8*24*60*60) OR on() vector(0)) +\n            (count(0<(ssl_kubernetes_cert_not_after{cluster="$cluster"}-time())<8*24*60*60) OR on() vector(0))\n            ',
             format=table,
             instant=true,
           )
@@ -100,100 +88,100 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           styles=[
             {
-          "alias": "SSL Failed",
-          "align": "auto",
-          "colorMode": "row",
-          "colors": [
-            "rgba(245,54,54,0.9)",
-            "rgba(237,129,40,0.89)",
-            "rgba(50,172,45,0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "mappingType": 1,
-          "pattern": "Value",
-          "thresholds": ["1"],
-          "type": "number",
-          "unit": "short"
-        },
-        { pattern: 'Time', type: 'hidden' },
-        { pattern: '__name__', type: 'hidden' },
+              alias: 'SSL Failed',
+              align: 'auto',
+              colorMode: 'row',
+              colors: [
+                'rgba(245,54,54,0.9)',
+                'rgba(237,129,40,0.89)',
+                'rgba(50,172,45,0.97)',
+              ],
+              dateFormat: 'YYYY-MM-DD HH:mm:ss',
+              decimals: 0,
+              mappingType: 1,
+              pattern: 'Value',
+              thresholds: ['1'],
+              type: 'number',
+              unit: 'short',
+            },
+            { pattern: 'Time', type: 'hidden' },
+            { pattern: '__name__', type: 'hidden' },
           ]
         ).addTarget(
           prometheus.target(
-            expr='ssl_probe_success{cluster=~"$cluster"}==0',
-            format="table",
+            expr='ssl_probe_success{cluster="$cluster"}==0',
+            format='table',
             intervalFactor=1,
             instant=true,
-            legendFormat="",
+            legendFormat='',
           )
         );
 
-      local sslExternalDesc = "External SSL Certificates";
-      local sslKubeconfigDesc = "Kubeconfig Certificates";
-      local sslK8sFileDesc = "Internal Kubernetes Certificates";
-      local sslK8sSecretDesc = "Kubernetes Secret Certificates";
+      local sslExternalDesc = 'External SSL Certificates';
+      local sslKubeconfigDesc = 'Kubeconfig Certificates';
+      local sslK8sFileDesc = 'Internal Kubernetes Certificates';
+      local sslK8sSecretDesc = 'Kubernetes Secret Certificates';
       local colors = [$._config.grafanaDashboards.color.red, $._config.grafanaDashboards.color.orange, $._config.grafanaDashboards.color.green];
 
       /* Template  for certificate table */
-      local ssl_exporter_table (title, ssl_metric, columns) =
+      local ssl_exporter_table(title, ssl_metric, columns) =
         table.new(
           title=title,
           datasource='$datasource',
           sort={ col: 3 },
           styles=[
-            { pattern: 'Time', type: 'hidden' },
-            { pattern: '__name__', type: 'hidden' },
-            { pattern: 'pod', type: 'hidden' },
-            { pattern: 'job', type: 'hidden' },
-            { pattern: 'endpoint', type: 'hidden' },
-            { pattern: 'namespace', type: 'hidden' },
-            { pattern: 'prometheus', type: 'hidden' },
-            { pattern: 'container', type: 'hidden' },
-            { pattern: 'prometheus_replica', type: 'hidden' },
-            { pattern: 'service', type: 'hidden' },
-            { alias: 'Serial No ', pattern: 'serial_no' }
-          ]
-          +columns
-          +[{ alias: 'TTL', pattern: 'Value', type: 'number', colors: colors, colorMode: 'cell', thresholds: [0, 8 * 24 * 60 * 60], unit: 's', decimals: 0 },]
+                   { pattern: 'Time', type: 'hidden' },
+                   { pattern: '__name__', type: 'hidden' },
+                   { pattern: 'pod', type: 'hidden' },
+                   { pattern: 'job', type: 'hidden' },
+                   { pattern: 'endpoint', type: 'hidden' },
+                   { pattern: 'namespace', type: 'hidden' },
+                   { pattern: 'prometheus', type: 'hidden' },
+                   { pattern: 'container', type: 'hidden' },
+                   { pattern: 'prometheus_replica', type: 'hidden' },
+                   { pattern: 'service', type: 'hidden' },
+                   { alias: 'Serial No ', pattern: 'serial_no' },
+                 ]
+                 + columns
+                 + [{ alias: 'TTL', pattern: 'Value', type: 'number', colors: colors, colorMode: 'cell', thresholds: [0, 8 * 24 * 60 * 60], unit: 's', decimals: 0 }]
         )
         .addTarget(
           prometheus.target(
             format='table',
             instant=true,
             expr=ssl_metric
-            )
+          )
         );
 
       local externalCerts = ssl_exporter_table(
-          title=sslExternalDesc,
-          ssl_metric='ssl_cert_not_after{ job=~"$job", cluster=~"$cluster" } - time()',
-          columns=
-          [
-            { alias: 'Instance', pattern: 'instance', type: 'string' },
-            { alias: 'CN', pattern: 'cn', type: 'string' },
-            { alias: 'Issuer CN', pattern: 'issuer_cn', type: 'string' },
-            { alias: 'DNS Names', pattern: 'dnsnames', type: 'string' },
-          ]
+        title=sslExternalDesc,
+        ssl_metric='ssl_cert_not_after{ job=~"$job", cluster="$cluster" } - time()',
+        columns=
+        [
+          { alias: 'Instance', pattern: 'instance', type: 'string' },
+          { alias: 'CN', pattern: 'cn', type: 'string' },
+          { alias: 'Issuer CN', pattern: 'issuer_cn', type: 'string' },
+          { alias: 'DNS Names', pattern: 'dnsnames', type: 'string' },
+        ]
       );
 
       local k8sKubeconfig = ssl_exporter_table(
-          title=sslKubeconfigDesc,
-          ssl_metric='ssl_kubeconfig_cert_not_after{ job=~"$job", cluster=~"$cluster" } - time()',
-          columns=
-          [
-            { pattern: 'dnsnames', type: 'hidden' },
-            { pattern: 'instance', type: 'hidden' },
-            { alias: 'Name', pattern: 'name', type: 'string' },
-            { alias: 'CN', pattern: 'cn', type: 'string' },
-            { alias: 'Issuer CN', pattern: 'issuer_cn', type: 'string' },
-            { alias: 'Kubeconfig', pattern: 'kubeconfig', type: 'string' },
-          ]
+        title=sslKubeconfigDesc,
+        ssl_metric='ssl_kubeconfig_cert_not_after{ job=~"$job", cluster="$cluster" } - time()',
+        columns=
+        [
+          { pattern: 'dnsnames', type: 'hidden' },
+          { pattern: 'instance', type: 'hidden' },
+          { alias: 'Name', pattern: 'name', type: 'string' },
+          { alias: 'CN', pattern: 'cn', type: 'string' },
+          { alias: 'Issuer CN', pattern: 'issuer_cn', type: 'string' },
+          { alias: 'Kubeconfig', pattern: 'kubeconfig', type: 'string' },
+        ]
       );
 
       local k8sFiles = ssl_exporter_table(
         title=sslK8sFileDesc,
-        ssl_metric='ssl_file_cert_not_after{ job=~"$job", cluster=~"$cluster" }* on(pod) group_left(node) kube_pod_info{ cluster=~"$cluster"} - time()',
+        ssl_metric='ssl_file_cert_not_after{ job=~"$job", cluster="$cluster" }* on(pod) group_left(node) kube_pod_info{ cluster="$cluster"} - time()',
         columns=
         [
           { pattern: 'dnsnames', type: 'hidden' },
@@ -207,7 +195,7 @@ local statPanel = grafana.statPanel;
 
       local k8sSecrets = ssl_exporter_table(
         title=sslK8sSecretDesc,
-        ssl_metric='ssl_kubernetes_cert_not_after{ job=~"$job", cluster=~"$cluster" } - time()',
+        ssl_metric='ssl_kubernetes_cert_not_after{ job=~"$job", cluster="$cluster" } - time()',
         columns=
         [
           { alias: 'CN', pattern: 'cn', type: 'string' },
@@ -218,28 +206,28 @@ local statPanel = grafana.statPanel;
 
       local panels = [
         row.new('Overview') { gridPos: { x: 0, y: 0, w: 24, h: 1 } },
-        totalUniqueCerts { gridPos: { x: 0, y: 1, w: 6, h: 6  } },
-        totalProbeTargets { gridPos: { x: 6, y: 1, w: 6, h: 6  } },
+        totalUniqueCerts { gridPos: { x: 0, y: 1, w: 6, h: 6 } },
+        totalProbeTargets { gridPos: { x: 6, y: 1, w: 6, h: 6 } },
         failedSSLCount { gridPos: { x: 12, y: 1, w: 6, h: 6 } },
         nearingExpiryCount { gridPos: { x: 18, y: 1, w: 6, h: 6 } },
 
-        row.new('Failed SSL Connects') {gridPos: { x: 0, y: 7, w: 6, h: 1 } },
+        row.new('Failed SSL Connects') { gridPos: { x: 0, y: 7, w: 6, h: 1 } },
         failedSSLConnect { gridPos: { x: 0, y: 8, w: 24, h: 6 } },
 
         row.new(sslExternalDesc) { gridPos: { x: 0, y: 14, w: 40, h: 1 } },
-        externalCerts { gridPos: { x: 0, y:15, w: 48, h:8 } },
+        externalCerts { gridPos: { x: 0, y: 15, w: 48, h: 8 } },
 
         row.new(sslKubeconfigDesc, collapse=true) { gridPos: { x: 0, y: 23, w: 40, h: 1 } }
-        .addPanel(k8sKubeconfig { tooltip+: { sort: 2 } }, { x: 0, y: 24, w: 40, h: 8 } ),
+        .addPanel(k8sKubeconfig { tooltip+: { sort: 2 } }, { x: 0, y: 24, w: 40, h: 8 }),
 
         row.new(sslK8sFileDesc, collapse=true) { gridPos: { x: 0, y: 32, w: 40, h: 1 } }
-        .addPanel(k8sFiles { tooltip+: { sort: 2 } }, { x: 0, y: 33, w: 40, h: 8 } ),
+        .addPanel(k8sFiles { tooltip+: { sort: 2 } }, { x: 0, y: 33, w: 40, h: 8 }),
 
         row.new(sslK8sSecretDesc, collapse=true) { gridPos: { x: 0, y: 41, w: 40, h: 1 } }
-        .addPanel(k8sSecrets { tooltip+: { sort: 2 } }, { x: 0, y: 40, w: 42, h: 8 } ),
+        .addPanel(k8sSecrets { tooltip+: { sort: 2 } }, { x: 0, y: 40, w: 42, h: 8 }),
       ];
 
-      dashboard.new (
+      dashboard.new(
         'SSL Certificates',
         editable=$._config.grafanaDashboards.editable,
         graphTooltip=$._config.grafanaDashboards.tooltip,
@@ -251,8 +239,8 @@ local statPanel = grafana.statPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(ssl_probe_success{cluster=~"$cluster"}, job)'),
-        $.grafanaTemplates.instanceTemplate('label_values({job=~"$job"}, instance)')
+        $.grafanaTemplates.jobTemplate('label_values(ssl_probe_success{cluster="$cluster"}, job)'),
+        $.grafanaTemplates.instanceTemplate('label_values({job=~"$job"}, instance)'),
       ])
       .addPanels(panels),
   },

--- a/jsonnet/dashboards/grafana-templates.libsonnet
+++ b/jsonnet/dashboards/grafana-templates.libsonnet
@@ -100,20 +100,13 @@ local template = grafana.template;
       ),
 
     clusterTemplate(query, hide='')::
-
-      // cluster variable will be hide if there is only 1 cluster and hide parameter is not set
-      local hideVariable =
-        if hide == '' then
-          if $.isMultiClusterMonitoring() then '' else 'variable'
-        else hide;
-
       baseTemplate(
         name='cluster',
         label='Cluster',
         query=query,
         includeAll=false,
         multi=false,
-        hide=hideVariable,
+        hide=hide,
       ),
 
     instanceTemplate(query, label='Instance', regex='')::
@@ -261,7 +254,7 @@ local template = grafana.template;
       baseTemplate(
         name='masterInstance',
         label='Master Instance',
-        query='label_values(master_uname_info{cluster=~"$cluster"}, instance)',
+        query='label_values(master_uname_info{cluster="$cluster"}, instance)',
         hide='variable',
       ),
 
@@ -269,7 +262,7 @@ local template = grafana.template;
       baseTemplate(
         name='workerInstance',
         label='Worker Instance',
-        query='label_values(worker_uname_info{cluster=~"$cluster"}, instance)',
+        query='label_values(worker_uname_info{cluster="$cluster"}, instance)',
         hide='variable',
       ),
   },

--- a/jsonnet/dashboards/hosts/alert-overview.libsonnet
+++ b/jsonnet/dashboards/hosts/alert-overview.libsonnet
@@ -38,8 +38,8 @@ local table = grafana.tablePanel;
             { alias: 'Alertname', pattern: 'alertname', type: 'string' },
             { alias: 'Job', pattern: 'job', type: 'string' },
             { alias: 'Node', pattern: 'nodename', type: 'string' },
-            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row'},
-            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row'},
+            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row' },
+            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row' },
           ]
         )
         .addTargets([

--- a/jsonnet/dashboards/k8s/alert-overview.libsonnet
+++ b/jsonnet/dashboards/k8s/alert-overview.libsonnet
@@ -34,14 +34,14 @@ local table = grafana.tablePanel;
           title='Alerts Info',
           datasource='$datasource',
           styles=[
-            { alias: 'Starts At', pattern: 'Time', type: 'date'},
-            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row'},
-            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row'},
+            { alias: 'Starts At', pattern: 'Time', type: 'date' },
+            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row' },
+            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row' },
           ]
         )
         .addTargets([
-          prometheus.target('ALERTS{cluster=~"$cluster", alertname!="Watchdog", alertstate=~"firing|pending", severity="warning", severity=~"$severity", alertgroup=~"$alertgroup"} * 2', format='table', instant=true),
-          prometheus.target('ALERTS{cluster=~"$cluster", alertname!="Watchdog", alertstate=~"firing|pending", severity="critical", severity=~"$severity", alertgroup=~"$alertgroup"} * 3', format='table', instant=true),
+          prometheus.target('ALERTS{cluster="$cluster", alertname!="Watchdog", alertstate=~"firing|pending", severity="warning", severity=~"$severity", alertgroup=~"$alertgroup"} * 2', format='table', instant=true),
+          prometheus.target('ALERTS{cluster="$cluster", alertname!="Watchdog", alertstate=~"firing|pending", severity="critical", severity=~"$severity", alertgroup=~"$alertgroup"} * 3', format='table', instant=true),
         ])
         .addTransformations([
           {

--- a/jsonnet/dashboards/k8s/api-server.libsonnet
+++ b/jsonnet/dashboards/k8s/api-server.libsonnet
@@ -32,7 +32,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           unit='percentunit',
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster=~"$cluster", verb="all"}' % availabilityDays)),
+        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster="$cluster", verb="all"}' % availabilityDays)),
 
       local errorBudget =
         graphPanel.new(
@@ -40,7 +40,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           format='percentunit',
         )
-        .addTarget(prometheus.target('100 * (apiserver_request:availability%dd{cluster=~"$cluster", verb="all"} - %f)' % [availabilityDays, errorBudgetTarget], legendFormat='errorbudget')),
+        .addTarget(prometheus.target('100 * (apiserver_request:availability%dd{cluster="$cluster", verb="all"} - %f)' % [availabilityDays, errorBudgetTarget], legendFormat='errorbudget')),
 
       local readAvailability =
         statPanel.new(
@@ -48,7 +48,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           unit='percentunit',
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster=~"$cluster", verb="read"}' % availabilityDays)),
+        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster="$cluster", verb="read"}' % availabilityDays)),
 
       local readRequests =
         graphPanel.new(
@@ -62,7 +62,7 @@ local errorBudgetTarget = 0.99;
         .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
         .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
         .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
-        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="read"})', legendFormat='{{code}}')),
+        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="read"})', legendFormat='{{code}}')),
 
       local readErrors =
         graphPanel.new(
@@ -71,7 +71,7 @@ local errorBudgetTarget = 0.99;
           min=0,
           format='percentunit',
         )
-        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="read", code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="read"})', legendFormat='{{resource}}')),
+        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="read", code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="read"})', legendFormat='{{resource}}')),
 
       local readDuration =
         graphPanel.new(
@@ -79,7 +79,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{cluster=~"$cluster", verb="read"}', legendFormat='{{resource}}')),
+        .addTarget(prometheus.target('cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{cluster="$cluster", verb="read"}', legendFormat='{{resource}}')),
 
       local writeAvailability =
         statPanel.new(
@@ -87,7 +87,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           unit='percentunit',
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster=~"$cluster", verb="write"}' % availabilityDays)),
+        .addTarget(prometheus.target('apiserver_request:availability%dd{cluster="$cluster", verb="write"}' % availabilityDays)),
 
       local writeRequests =
         graphPanel.new(
@@ -101,7 +101,7 @@ local errorBudgetTarget = 0.99;
         .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
         .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
         .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
-        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="write"})', legendFormat='{{code}}')),
+        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="write"})', legendFormat='{{code}}')),
 
       local writeErrors =
         graphPanel.new(
@@ -110,7 +110,7 @@ local errorBudgetTarget = 0.99;
           min=0,
           format='percentunit',
         )
-        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="write", code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster=~"$cluster", verb="write"})', legendFormat='{{resource}}')),
+        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="write", code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{cluster="$cluster", verb="write"})', legendFormat='{{resource}}')),
 
       local writeDuration =
         graphPanel.new(
@@ -118,7 +118,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           format='s',
         )
-        .addTarget(prometheus.target('cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{cluster=~"$cluster", verb="write"}', legendFormat='{{resource}}')),
+        .addTarget(prometheus.target('cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{cluster="$cluster", verb="write"}', legendFormat='{{resource}}')),
 
       local health =
         statPanel.new(
@@ -137,10 +137,10 @@ local errorBudgetTarget = 0.99;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(apiserver_request_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
-            prometheus.target('sum(rate(apiserver_request_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
-            prometheus.target('sum(rate(apiserver_request_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
-            prometheus.target('sum(rate(apiserver_request_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
+            prometheus.target('sum(rate(apiserver_request_total{cluster="$cluster", %(apiServer)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
+            prometheus.target('sum(rate(apiserver_request_total{cluster="$cluster", %(apiServer)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
+            prometheus.target('sum(rate(apiserver_request_total{cluster="$cluster", %(apiServer)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
+            prometheus.target('sum(rate(apiserver_request_total{cluster="$cluster", %(apiServer)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
           ]
         ),
       local requestDuration =
@@ -148,7 +148,7 @@ local errorBudgetTarget = 0.99;
           title='Request duration 99th quantile',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{cluster=~"$cluster", %(apiServer)s, instance=~"$instance", verb!="WATCH"}[5m])) by (verb, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{cluster="$cluster", %(apiServer)s, instance=~"$instance", verb!="WATCH"}[5m])) by (verb, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}}')),
 
       local workQueueAddRate =
         graphPanel.new(
@@ -158,7 +158,7 @@ local errorBudgetTarget = 0.99;
           min=0,
           legend_show=false,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{cluster="$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local workQueueDepth =
         graphPanel.new(
@@ -167,7 +167,7 @@ local errorBudgetTarget = 0.99;
           min=0,
           legend_show=false,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_depth{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('sum(rate(workqueue_depth{cluster="$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local workQueueLatency =
         graphPanel.new(
@@ -179,7 +179,7 @@ local errorBudgetTarget = 0.99;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster="$cluster", %(apiServer)s, instance=~"$instance"}[5m])) by (instance, name, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local memory =
         graphPanel.new(
@@ -187,7 +187,7 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(apiServer)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local cpu =
         graphPanel.new(
@@ -195,14 +195,14 @@ local errorBudgetTarget = 0.99;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", %(apiServer)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", %(apiServer)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", %(apiServer)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       dashboard:
         dashboard.new(
@@ -217,7 +217,7 @@ local errorBudgetTarget = 0.99;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(apiserver_request_total, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(apiserver_request_total{cluster=~"$cluster", %(apiServer)s}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(apiserver_request_total{cluster="$cluster", %(apiServer)s}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/container-detail.libsonnet
+++ b/jsonnet/dashboards/k8s/container-detail.libsonnet
@@ -39,9 +39,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(kube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(kube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(kube_pod_container_resource_requests{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(kube_pod_container_resource_limits{resource="cpu", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodLimits - {{$view}}'),
           ]
         )
         .addSeriesOverride({ alias: '/PodRequests/', color: $._config.grafanaDashboards.color.red, dashes: true, fill: 0, stack: false, hideTooltip: true })
@@ -60,9 +60,9 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(container_memory_working_set_bytes{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", id!="", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
-            prometheus.target('sum(kube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodRequests - {{$view}}'),
-            prometheus.target('sum(kube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodLimits - {{$view}}'),
+            prometheus.target('sum(container_memory_working_set_bytes{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container!="POD", id!="", container=~"$container"}) by ($view)', legendFormat='{{$view}}'),
+            prometheus.target('sum(kube_pod_container_resource_requests{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodRequests - {{$view}}'),
+            prometheus.target('sum(kube_pod_container_resource_limits{resource="memory", cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"}) by ($view)', legendFormat='PodLimits - {{$view}}'),
           ]
         )
         .addSeriesOverride({ alias: '/PodRequests/', color: $._config.grafanaDashboards.color.red, dashes: true, fill: 0, stack: false, hideTooltip: true })
@@ -80,8 +80,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ]
         )
         .addSeriesOverride({ alias: '/Rx_/', stack: 'B', transform: 'negative-Y' })
@@ -99,8 +99,8 @@ local row = grafana.row;
         )
         .addTargets(
           [
-            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
-            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Tx_{{pod}}'),
+            prometheus.target('sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}[5m])) by (pod)', legendFormat='Rx_{{pod}}'),
           ]
         )
         .addSeriesOverride({ alias: '/Rx_/', stack: 'B', transform: 'negative-Y' })
@@ -122,7 +122,7 @@ local row = grafana.row;
           legend_values=true,
         )
         .addSeriesOverride({ alias: 'Value #A', legend: false, hiddenSeries: true })
-        .addTarget(loki.target('sum(count_over_time({cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
+        .addTarget(loki.target('sum(count_over_time({cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"[10s])) by ($view)', legendFormat='{{$view}}'));
 
       local logs =
         logPanel.new(
@@ -130,7 +130,7 @@ local row = grafana.row;
           datasource='$datasource_logs',
           showLabels=true,
         )
-        .addTarget(loki.target('{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
+        .addTarget(loki.target('{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", container=~"$container"} |~ "(?i)$search"'));
 
       local templates =
         [
@@ -140,10 +140,10 @@ local row = grafana.row;
         + [
           $.grafanaTemplates.viewByTemplate('pod,container'),
           $.grafanaTemplates.clusterTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster=~"$cluster"}, node)', label='Node'),
-          $.grafanaTemplates.namespaceTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance"}, namespace)'),
-          $.grafanaTemplates.podTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}, pod)'),
-          $.grafanaTemplates.containerTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", pod=~"$pod"}, container)'),
+          $.grafanaTemplates.instanceTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster="$cluster"}, node)', label='Node'),
+          $.grafanaTemplates.namespaceTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster="$cluster", node=~"$instance"}, namespace)'),
+          $.grafanaTemplates.podTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", namespace=~"$namespace"}, pod)'),
+          $.grafanaTemplates.containerTemplate('label_values(node_namespace_pod_container:container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", namespace=~"$namespace", pod=~"$pod"}, container)'),
         ]
         + if $._config.grafanaDashboards.isLoki then [$.grafanaTemplates.searchTemplate()] else [];
 

--- a/jsonnet/dashboards/k8s/controller-manager.libsonnet
+++ b/jsonnet/dashboards/k8s/controller-manager.libsonnet
@@ -43,7 +43,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local workQueueDepth =
         graphPanel.new(
@@ -55,7 +55,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_depth{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('sum(rate(workqueue_depth{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local workQueueLatency =
         graphPanel.new(
@@ -67,7 +67,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}[5m])) by (instance, name, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{name}}')),
 
       local grpcRate =
         graphPanel.new(
@@ -77,10 +77,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
           ]
         ),
 
@@ -91,7 +91,7 @@ local statPanel = grafana.statPanel;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(controllerManager)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local getRequestLatency =
         graphPanel.new(
@@ -104,7 +104,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(controllerManager)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local memory =
         graphPanel.new(
@@ -112,7 +112,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local cpu =
         graphPanel.new(
@@ -120,14 +120,14 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", %(controllerManager)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", %(controllerManager)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       dashboard:
         dashboard.new(
@@ -142,7 +142,7 @@ local statPanel = grafana.statPanel;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(workqueue_adds_total, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster=~"$cluster", %(controllerManager)s}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster="$cluster", %(controllerManager)s}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/cpu-namespace-overview.libsonnet
+++ b/jsonnet/dashboards/k8s/cpu-namespace-overview.libsonnet
@@ -35,7 +35,7 @@ local graphPanel = grafana.graphPanel;
         )
         .addTarget(
           prometheus.target(
-            'sum(rate(\ncontainer_cpu_usage_seconds_total{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}[5m])\n* on(namespace, pod)\ngroup_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", workload=~"$workload", workload_type=~"$workload_type"})\nby (pod) or on() sum(rate(container_cpu_usage_seconds_total{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}[5m])) by (pod)',
+            'sum(rate(\ncontainer_cpu_usage_seconds_total{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}[5m])\n* on(namespace, pod)\ngroup_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", workload=~"$workload", workload_type=~"$workload_type"})\nby (pod) or on() sum(rate(container_cpu_usage_seconds_total{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}[5m])) by (pod)',
             legendFormat='{{pod}}'
           ),
         );
@@ -60,13 +60,13 @@ local graphPanel = grafana.graphPanel;
         )
         .addTargets(
           [
-            prometheus.target(format='table', instant=true, expr='count(sum(container_cpu_usage_seconds_total{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (namespace, pod)) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace"} * on(pod, namespace) group_left(node) node_namespace_pod:kube_pod_info:{cluster=~"$cluster", namespace=~"$namespace", node=~"$instance"}) by (workload, namespace)) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(rate(container_cpu_usage_seconds_total{cluster=~"$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace, pod, container) * group(kube_pod_container_resource_requests{resource="cpu", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
-            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(rate(container_cpu_usage_seconds_total{cluster=~"$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace, pod, container) * group(kube_pod_container_resource_limits{resource="cpu", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
-            prometheus.target(format='table', instant=true, expr='sum(rate(container_cpu_usage_seconds_total{cluster=~"$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='count(sum(container_cpu_usage_seconds_total{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (namespace, pod)) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace"} * on(pod, namespace) group_left(node) node_namespace_pod:kube_pod_info:{cluster="$cluster", namespace=~"$namespace", node=~"$instance"}) by (workload, namespace)) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_requests{resource="cpu", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(rate(container_cpu_usage_seconds_total{cluster="$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace, pod, container) * group(kube_pod_container_resource_requests{resource="cpu", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
+            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_limits{resource="cpu", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(rate(container_cpu_usage_seconds_total{cluster="$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace, pod, container) * group(kube_pod_container_resource_limits{resource="cpu", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
+            prometheus.target(format='table', instant=true, expr='sum(rate(container_cpu_usage_seconds_total{cluster="$cluster", container!~"POD|", id!="", node=~"$instance", namespace=~"$namespace"}[5m])) by (namespace)'),
           ],
         );
 
@@ -82,11 +82,11 @@ local graphPanel = grafana.graphPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(kube_pod_info, cluster)'),
-        $.grafanaTemplates.instanceTemplate('label_values(kube_pod_info{cluster=~"$cluster"}, node)', label='Node'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster=~"$cluster", node=~"$instance"}, namespace)'),
-        $.grafanaTemplates.podTemplate('label_values(kube_pod_info{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}, pod)', hide='variable'),
-        $.grafanaTemplates.workloadTypeTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}, workload_type)'),
-        $.grafanaTemplates.workloadTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", workload_type=~"$workload_type"}, workload)'),
+        $.grafanaTemplates.instanceTemplate('label_values(kube_pod_info{cluster="$cluster"}, node)', label='Node'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster="$cluster", node=~"$instance"}, namespace)'),
+        $.grafanaTemplates.podTemplate('label_values(kube_pod_info{cluster="$cluster", node=~"$instance", namespace=~"$namespace"}, pod)', hide='variable'),
+        $.grafanaTemplates.workloadTypeTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}, workload_type)'),
+        $.grafanaTemplates.workloadTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", workload_type=~"$workload_type"}, workload)'),
       ])
       .addPanels(
         [

--- a/jsonnet/dashboards/k8s/etcd.libsonnet
+++ b/jsonnet/dashboards/k8s/etcd.libsonnet
@@ -44,8 +44,8 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(grpc_server_started_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_type="unary"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='GRPC_Rate'),
-            prometheus.target('sum(rate(grpc_server_handled_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_type="unary", grpc_code!="OK"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='GRPC Failed Rate'),
+            prometheus.target('sum(rate(grpc_server_started_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_type="unary"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='GRPC_Rate'),
+            prometheus.target('sum(rate(grpc_server_handled_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_type="unary", grpc_code!="OK"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='GRPC Failed Rate'),
           ]
         ),
 
@@ -59,8 +59,8 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(grpc_server_started_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Watch", grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Watch", grpc_type="bidi_stream"})' % $._config.grafanaDashboards.selectors, legendFormat='Watch Streams'),
-            prometheus.target('sum(grpc_server_started_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Lease", grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Lease", grpc_type="bidi_stream"})' % $._config.grafanaDashboards.selectors, legendFormat='Lease Streams'),
+            prometheus.target('sum(grpc_server_started_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Watch", grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Watch", grpc_type="bidi_stream"})' % $._config.grafanaDashboards.selectors, legendFormat='Watch Streams'),
+            prometheus.target('sum(grpc_server_started_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Lease", grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{cluster="$cluster", %(etcd)s, instance=~"$instance", grpc_service="etcdserverpb.Lease", grpc_type="bidi_stream"})' % $._config.grafanaDashboards.selectors, legendFormat='Lease Streams'),
           ]
         ),
 
@@ -73,7 +73,7 @@ local statPanel = grafana.statPanel;
           fill=0,
           legend_show=false,
         )
-        .addTarget(prometheus.target('etcd_mvcc_db_total_size_in_bytes{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} DB Size')),
+        .addTarget(prometheus.target('etcd_mvcc_db_total_size_in_bytes{cluster="$cluster", %(etcd)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} DB Size')),
 
       local diskSyncDuration =
         graphPanel.new(
@@ -87,8 +87,8 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} WAL fsync'),
-            prometheus.target('histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} DB fsync'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} WAL fsync'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} DB fsync'),
           ]
         ),
 
@@ -101,7 +101,7 @@ local statPanel = grafana.statPanel;
           fill=0,
           legend_show=false,
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Resident Memory')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(etcd)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Resident Memory')),
 
       local clientTrafficIn =
         graphPanel.new(
@@ -111,7 +111,7 @@ local statPanel = grafana.statPanel;
           fill=5,
           legend_show=false,
         )
-        .addTarget(prometheus.target('rate(etcd_network_client_grpc_sent_bytes_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Client Traffic In')),
+        .addTarget(prometheus.target('rate(etcd_network_client_grpc_sent_bytes_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Client Traffic In')),
 
       local clientTrafficOut =
         graphPanel.new(
@@ -121,7 +121,7 @@ local statPanel = grafana.statPanel;
           fill=5,
           legend_show=false,
         )
-        .addTarget(prometheus.target('rate(etcd_network_client_grpc_sent_bytes_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Client Traffic Out')),
+        .addTarget(prometheus.target('rate(etcd_network_client_grpc_sent_bytes_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} Client Traffic Out')),
 
       local totalLeaderElectionsPerDay =
         graphPanel.new(
@@ -131,7 +131,7 @@ local statPanel = grafana.statPanel;
           fill=0,
           legend_show=false,
         )
-        .addTarget(prometheus.target('changes(etcd_server_leader_changes_seen_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[1d])' % $._config.grafanaDashboards.selectors, legendFormat='Total Leader Elections Per Day')),
+        .addTarget(prometheus.target('changes(etcd_server_leader_changes_seen_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[1d])' % $._config.grafanaDashboards.selectors, legendFormat='Total Leader Elections Per Day')),
 
       local raftproposal =
         graphPanel.new(
@@ -143,10 +143,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(etcd_server_proposals_failed_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Failure Rate'),
-            prometheus.target('sum(etcd_server_proposals_pending{cluster=~"$cluster", %(etcd)s, instance=~"$instance"})' % $._config.grafanaDashboards.selectors, legendFormat='etcd_server_proposals_pending'),
-            prometheus.target('sum(rate(etcd_server_proposals_committed_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Commit Rate'),
-            prometheus.target('sum(rate(etcd_server_proposals_applied_total{cluster=~"$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Apply Rate'),
+            prometheus.target('sum(rate(etcd_server_proposals_failed_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Failure Rate'),
+            prometheus.target('sum(etcd_server_proposals_pending{cluster="$cluster", %(etcd)s, instance=~"$instance"})' % $._config.grafanaDashboards.selectors, legendFormat='etcd_server_proposals_pending'),
+            prometheus.target('sum(rate(etcd_server_proposals_committed_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Commit Rate'),
+            prometheus.target('sum(rate(etcd_server_proposals_applied_total{cluster="$cluster", %(etcd)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='Proposal Apply Rate'),
           ]
         ),
 
@@ -163,7 +163,7 @@ local statPanel = grafana.statPanel;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(etcd_server_has_leader, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(etcd_server_has_leader{cluster=~"$cluster", %(etcd)s}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(etcd_server_has_leader{cluster="$cluster", %(etcd)s}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/k8s-overview-dashboards.libsonnet
+++ b/jsonnet/dashboards/k8s/k8s-overview-dashboards.libsonnet
@@ -73,8 +73,8 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.containerTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_pod_container_info, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_container_info{cluster=~"$cluster"}, namespace)'),
-        $.grafanaTemplates.podTemplate('label_values(kube_pod_container_info{cluster=~"$cluster", namespace=~"$namespace"}, pod)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_container_info{cluster="$cluster"}, namespace)'),
+        $.grafanaTemplates.podTemplate('label_values(kube_pod_container_info{cluster="$cluster", namespace=~"$namespace"}, pod)'),
       ],
     ) +
 
@@ -88,7 +88,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.jobNameTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_job_info, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_job_info{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_job_info{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -102,7 +102,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.daemonsetTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_daemonset_status_desired_number_scheduled, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_daemonset_status_desired_number_scheduled{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_daemonset_status_desired_number_scheduled{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -116,7 +116,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.deploymentTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_deployment_status_replicas, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_deployment_status_replicas{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_deployment_status_replicas{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -130,7 +130,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.podTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_pod_info, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -144,7 +144,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.statefulsetTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_statefulset_status_replicas, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_statefulset_status_replicas{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_statefulset_status_replicas{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -158,7 +158,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=$.grafanaTemplates.pvcTemplate,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_persistentvolumeclaim_info, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_persistentvolumeclaim_info{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_persistentvolumeclaim_info{cluster="$cluster"}, namespace)'),
       ],
     ) +
 
@@ -172,7 +172,7 @@ local table = grafana.tablePanel;
       customizableGrafanaTemplateFunction=null,
       grafanaTemplates=[
         $.grafanaTemplates.clusterTemplate('label_values(kube_node_status_condition, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_persistentvolumeclaim_info{cluster=~"$cluster"}, namespace)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_persistentvolumeclaim_info{cluster="$cluster"}, namespace)'),
       ],
     ),
 

--- a/jsonnet/dashboards/k8s/kubelet.libsonnet
+++ b/jsonnet/dashboards/k8s/kubelet.libsonnet
@@ -43,7 +43,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (operation_type, instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
+        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (operation_type, instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
 
       local operationErrorRate =
         graphPanel.new(
@@ -56,7 +56,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_errors_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
+        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_errors_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
 
       local operationLatency =
         graphPanel.new(
@@ -68,7 +68,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
 
       local podStartRate =
         graphPanel.new(
@@ -83,8 +83,8 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(kubelet_pod_start_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} pod'),
-            prometheus.target('sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} worker'),
+            prometheus.target('sum(rate(kubelet_pod_start_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} pod'),
+            prometheus.target('sum(rate(kubelet_pod_worker_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} worker'),
           ]
         ),
 
@@ -101,8 +101,8 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} pod'),
-            prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} worker'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} pod'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} worker'),
           ]
         ),
 
@@ -119,7 +119,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
+        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
 
       local storageOperationErrorRate =
         graphPanel.new(
@@ -134,7 +134,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", status="fail-unknown"}[5m])) by (instance, operation_name, volume_plugin)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
+        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", status="fail-unknown"}[5m])) by (instance, operation_name, volume_plugin)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
 
       local storageOperationLatency =
         graphPanel.new(
@@ -149,7 +149,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}')),
 
       local cgroupManagerRate =
         graphPanel.new(
@@ -162,7 +162,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config.grafanaDashboards.selectors, legendFormat='{{operation_type}}')),
+        .addTarget(prometheus.target('sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config.grafanaDashboards.selectors, legendFormat='{{operation_type}}')),
 
       local cgroupManagerDuration =
         graphPanel.new(
@@ -175,7 +175,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{operation_type}}')),
 
       local plegRelistRate =
         graphPanel.new(
@@ -189,7 +189,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_pleg_relist_duration_seconds_count{cluster=~"$cluster", %(kubelet)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('sum(rate(kubelet_pleg_relist_duration_seconds_count{cluster="$cluster", %(kubelet)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local plegRelistDuration =
         graphPanel.new(
@@ -202,7 +202,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local plegRelistInterval =
         graphPanel.new(
@@ -215,7 +215,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local grpcRate =
         graphPanel.new(
@@ -226,10 +226,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
           ]
         ),
 
@@ -244,7 +244,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])) by (instance, verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} {{verb}} {{url}}')),
 
       local memory =
         graphPanel.new(
@@ -252,7 +252,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local cpu =
         graphPanel.new(
@@ -260,14 +260,14 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       dashboard:
         dashboard.new(
@@ -282,7 +282,7 @@ local statPanel = grafana.statPanel;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(kube_pod_info, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(kubelet_runtime_operations_total{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics"}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(kubelet_runtime_operations_total{cluster="$cluster", %(kubelet)s, metrics_path="/metrics"}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/memory-namespace-overview.libsonnet
+++ b/jsonnet/dashboards/k8s/memory-namespace-overview.libsonnet
@@ -34,7 +34,7 @@ local graphPanel = grafana.graphPanel;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target(legendFormat='{{pod}}', expr='sum(\ncontainer_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}\n* on(namespace, pod)\ngroup_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", workload=~"$workload", workload_type=~"$workload_type"}\n) by (pod) or on() sum(container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (pod)'));
+        .addTarget(prometheus.target(legendFormat='{{pod}}', expr='sum(\ncontainer_memory_working_set_bytes{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}\n* on(namespace, pod)\ngroup_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", workload=~"$workload", workload_type=~"$workload_type"}\n) by (pod) or on() sum(container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (pod)'));
 
       local memReqTable =
         table.new(
@@ -56,13 +56,13 @@ local graphPanel = grafana.graphPanel;
         )
         .addTargets(
           [
-            prometheus.target(format='table', instant=true, expr='count(sum(container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (namespace, pod)) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace"} * on(pod, namespace) group_left(node) node_namespace_pod:kube_pod_info:{cluster=~"$cluster", namespace=~"$namespace", node=~"$instance"}) by (workload, namespace)) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace, pod, container) * group(kube_pod_container_resource_requests{resource="memory", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
-            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
-            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace, pod, container) * group(kube_pod_container_resource_limits{resource="memory", cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
-            prometheus.target(format='table', instant=true, expr='sum(container_memory_working_set_bytes{cluster=~"$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='count(sum(container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", namespace=~"$namespace", container!~"POD|", id!=""}) by (namespace, pod)) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace"} * on(pod, namespace) group_left(node) node_namespace_pod:kube_pod_info:{cluster="$cluster", namespace=~"$namespace", node=~"$instance"}) by (workload, namespace)) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_requests{resource="memory", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace, pod, container) * group(kube_pod_container_resource_requests{resource="memory", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
+            prometheus.target(format='table', instant=true, expr='sum(kube_pod_container_resource_limits{resource="memory", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace)'),
+            prometheus.target(format='table', instant=true, expr='sum by (namespace) (sum(container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace, pod, container) * group(kube_pod_container_resource_limits{resource="memory", cluster="$cluster", node=~"$instance", namespace=~"$namespace"}) by (namespace, pod, container))'),
+            prometheus.target(format='table', instant=true, expr='sum(container_memory_working_set_bytes{cluster="$cluster", node=~"$instance", container!~"POD|", id!="", namespace=~"$namespace"}) by (namespace)'),
           ]
         );
 
@@ -78,11 +78,11 @@ local graphPanel = grafana.graphPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(kube_pod_info, cluster)'),
-        $.grafanaTemplates.instanceTemplate('label_values(kube_pod_info{cluster=~"$cluster"}, node)', label='Node'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster=~"$cluster", node=~"$instance"}, namespace)'),
-        $.grafanaTemplates.podTemplate('label_values(kube_pod_info{cluster=~"$cluster", node=~"$instance", namespace=~"$namespace"}, pod)', hide='variable'),
-        $.grafanaTemplates.workloadTypeTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod"}, workload_type)'),
-        $.grafanaTemplates.workloadTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=~"$cluster", namespace=~"$namespace", pod=~"$pod", workload_type=~"$workload_type"}, workload)'),
+        $.grafanaTemplates.instanceTemplate('label_values(kube_pod_info{cluster="$cluster"}, node)', label='Node'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_pod_info{cluster="$cluster", node=~"$instance"}, namespace)'),
+        $.grafanaTemplates.podTemplate('label_values(kube_pod_info{cluster="$cluster", node=~"$instance", namespace=~"$namespace"}, pod)', hide='variable'),
+        $.grafanaTemplates.workloadTypeTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", pod=~"$pod"}, workload_type)'),
+        $.grafanaTemplates.workloadTemplate('label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster", namespace=~"$namespace", pod=~"$pod", workload_type=~"$workload_type"}, workload)'),
       ])
       .addPanels(
         [

--- a/jsonnet/dashboards/k8s/network-namespace-overview.libsonnet
+++ b/jsonnet/dashboards/k8s/network-namespace-overview.libsonnet
@@ -67,51 +67,51 @@ local graphPanel = grafana.graphPanel;
       local recPackErrGraphPanel =
         networkPanel(
           title='Rate of Received Packets Errors',
-          expr='sort_desc(sum(irate(node_network_receive_errs_total{cluster=~"$cluster", namespace=~".+", device!~"lo | veth. | docker.* | flannel.* | cali.* | cbr."}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(node_network_receive_errs_total{cluster="$cluster", namespace=~".+", device!~"lo | veth. | docker.* | flannel.* | cali.* | cbr."}[$interval:$resolution])) by (namespace))',
         );
 
       local transPackErrGraphPanel =
         networkPanel(
           title='Rate of Transmitted Packets Errors',
-          expr='sort_desc(sum(irate(node_network_transmit_errs_total{cluster=~"$cluster", namespace=~".+", device!~"lo | veth. | docker.* | flannel.* | cali.* | cbr."}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(node_network_transmit_errs_total{cluster="$cluster", namespace=~".+", device!~"lo | veth. | docker.* | flannel.* | cali.* | cbr."}[$interval:$resolution])) by (namespace))',
         );
 
       local recPackDropGraphPanel =
         networkPanel(
           title='Rate of Received Packets Dropped',
-          expr='sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       local transPackDropGraphPanel =
         networkPanel(
           title='Rate of Transmitted Packets Dropped',
-          expr='sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       local recBandGraphPanel =
         networkPanel(
           title='Receive Bandwidth',
           format='Bps',
-          expr='sort_desc(sum(irate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_receive_bytes_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       local transBandGraphPanel =
         networkPanel(
           title='Transmit Bandwidth',
           format='Bps',
-          expr='sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_transmit_bytes_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       local recPackGraphPanel =
         networkPanel(
           title='Rate of Received Packets',
-          expr='sort_desc(sum(irate(container_network_receive_packets_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_receive_packets_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       local transPackGraphPanel =
         networkPanel(
           title='Rate of Transmitted Packets',
-          expr='sort_desc(sum(irate(container_network_transmit_packets_total{cluster=~"$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          expr='sort_desc(sum(irate(container_network_transmit_packets_total{cluster="$cluster", namespace=~".+"}[$interval:$resolution])) by (namespace))',
         );
 
       dashboard.new(

--- a/jsonnet/dashboards/k8s/node-exporter.libsonnet
+++ b/jsonnet/dashboards/k8s/node-exporter.libsonnet
@@ -35,7 +35,7 @@ local table = grafana.tablePanel;
           decimals=0,
           unit='s',
         )
-        .addTarget(prometheus.target('avg(time() - node_boot_time_seconds{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
+        .addTarget(prometheus.target('avg(time() - node_boot_time_seconds{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
 
@@ -50,7 +50,7 @@ local table = grafana.tablePanel;
             { alias: 'IP Address', pattern: '_1_instance', type: 'string' },
           ]
         )
-        .addTarget(prometheus.target(format='table', instant=true, expr='sum by(_1_instance, _0_nodename) (\nlabel_replace(\nlabel_replace(\n  node_uname_info{cluster=~"$cluster", job=~"$job", nodename=~"$instance"}\n    , "_1_instance", "$1", "instance", "(.*):.*")\n    , "_0_nodename","$1", "nodename", "(.*)")\n)'));
+        .addTarget(prometheus.target(format='table', instant=true, expr='sum by(_1_instance, _0_nodename) (\nlabel_replace(\nlabel_replace(\n  node_uname_info{cluster="$cluster", job=~"$job", nodename=~"$instance"}\n    , "_1_instance", "$1", "instance", "(.*):.*")\n    , "_0_nodename","$1", "nodename", "(.*)")\n)'));
 
       local cpuCoresPanel =
         statPanel.new(
@@ -58,7 +58,7 @@ local table = grafana.tablePanel;
           datasource='$datasource',
           unit='short',
         )
-        .addTarget(prometheus.target('count(node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="system"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
+        .addTarget(prometheus.target('count(node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="system"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local memoryPanel =
@@ -68,7 +68,7 @@ local table = grafana.tablePanel;
           decimals=0,
           unit='bytes',
         )
-        .addTarget(prometheus.target('sum(node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
+        .addTarget(prometheus.target('sum(node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local cpuUtilPanel =
@@ -76,7 +76,7 @@ local table = grafana.tablePanel;
           title='CPU Utilization',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('round((1 - (avg(irate(node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="idle"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))))) * 100)'))
+        .addTarget(prometheus.target('round((1 - (avg(irate(node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="idle"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))))) * 100)'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local memUtilPanel =
@@ -87,7 +87,7 @@ local table = grafana.tablePanel;
           min=0,
           max=100,
         )
-        .addTarget(prometheus.target('round((1 - (sum(node_memory_MemAvailable_bytes{cluster=~"$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) / sum(node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) )) * 100)'))
+        .addTarget(prometheus.target('round((1 - (sum(node_memory_MemAvailable_bytes{cluster="$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) / sum(node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) )) * 100)'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local mostUtilDiskPanel =
@@ -98,7 +98,7 @@ local table = grafana.tablePanel;
           min=0,
           max=100,
         )
-        .addTarget(prometheus.target('round(\nmax(\n(sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (instance, device) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job"}) by (instance, device)) /\n(sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (instance, device) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job"}) by (instance, device) +\nsum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job"}) by (instance, device))\n * 100 \n * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))\n)\n)'))
+        .addTarget(prometheus.target('round(\nmax(\n(sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (instance, device) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job"}) by (instance, device)) /\n(sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (instance, device) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job"}) by (instance, device) +\nsum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job"}) by (instance, device))\n * 100 \n * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))\n)\n)'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local networkErrPanel =
@@ -109,7 +109,7 @@ local table = grafana.tablePanel;
           min=0,
           max=100,
         )
-        .addTarget(prometheus.target('sum(rate(node_network_transmit_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) + \nsum(rate(node_network_receive_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
+        .addTarget(prometheus.target('sum(rate(node_network_transmit_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) + \nsum(rate(node_network_receive_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m]) * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'))
         .addThreshold({ color: $._config.grafanaDashboards.color.blue, value: null });
 
       local cpuUtilGraphPanel =
@@ -120,7 +120,7 @@ local table = grafana.tablePanel;
           min=0,
           max=100,
         )
-        .addTarget(prometheus.target(legendFormat='cpu  - {{nodename}}', expr='round((1 - (avg by (nodename) (irate(node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="idle"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))))) * 100)'));
+        .addTarget(prometheus.target(legendFormat='cpu  - {{nodename}}', expr='round((1 - (avg by (nodename) (irate(node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="idle"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))))) * 100)'));
 
       local loadAverageGraphPanel =
         graphPanel.new(
@@ -132,10 +132,10 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/logical cores/', color: '#C4162A', linewidth: 2 })
         .addTargets(
           [
-            prometheus.target(legendFormat='1m load average {{nodename}}', expr='sum by (nodename) (node_load1{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='5m load average {{nodename}}', expr='sum by (nodename) (node_load5{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='15m load average {{nodename}}', expr='sum by (nodename) (node_load15{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='logical cores {{nodename}}', expr='count by (nodename) (node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="idle"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='1m load average {{nodename}}', expr='sum by (nodename) (node_load1{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='5m load average {{nodename}}', expr='sum by (nodename) (node_load5{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='15m load average {{nodename}}', expr='sum by (nodename) (node_load15{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='logical cores {{nodename}}', expr='count by (nodename) (node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="idle"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
           ]
         );
 
@@ -154,12 +154,12 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/free/', hiddenSeries: true })
         .addTargets(
           [
-            prometheus.target(legendFormat='memory used - {{nodename}}', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) - sum by (nodename) (node_memory_MemAvailable_bytes{cluster=~"$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='memory available - {{nodename}}', expr='sum by (nodename) (node_memory_MemAvailable_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='memory buffers - {{nodename}}', expr='sum by (nodename) (node_memory_Buffers_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='memory cached - {{nodename}}', expr='sum by (nodename) (node_memory_Cached_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='memory free - {{nodename}}', expr='sum by (nodename) (node_memory_MemFree_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
-            prometheus.target(legendFormat='memory total - {{nodename}}', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory used - {{nodename}}', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) - sum by (nodename) (node_memory_MemAvailable_bytes{cluster="$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory available - {{nodename}}', expr='sum by (nodename) (node_memory_MemAvailable_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory buffers - {{nodename}}', expr='sum by (nodename) (node_memory_Buffers_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory cached - {{nodename}}', expr='sum by (nodename) (node_memory_Cached_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory free - {{nodename}}', expr='sum by (nodename) (node_memory_MemFree_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='memory total - {{nodename}}', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
           ]
         );
 
@@ -177,10 +177,10 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/utilization/', yaxis: 2, lines: false, legend: false, pointradius: 0 })
         .addTargets(
           [
-            prometheus.target(legendFormat='disk used {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)  - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
-            prometheus.target(legendFormat='disk size {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
-            prometheus.target(legendFormat='disk available {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
-            prometheus.target(legendFormat='disk utilization {{device}} {{nodename}} {{mountpoint}}', expr='round((sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint)) / (sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) + sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename, mountpoint)) * 100 * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='disk used {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)  - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
+            prometheus.target(legendFormat='disk size {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
+            prometheus.target(legendFormat='disk available {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename, mountpoint)'),
+            prometheus.target(legendFormat='disk utilization {{device}} {{nodename}} {{mountpoint}}', expr='round((sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint)) / (sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype=~"$diskfs"}) by (device, instance, nodename, mountpoint) + sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename, mountpoint)) * 100 * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
           ]
         ) { yaxes: std.mapWithIndex(function(i, item) if (i == 1) then item { show: false } else item, super.yaxes) };  // Hide second Y axis
 
@@ -198,10 +198,10 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/utilization/', yaxis: 2, lines: false, legend: false, pointradius: 0 })
         .addTargets(
           [
-            prometheus.target(legendFormat='disk used {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)  - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
-            prometheus.target(legendFormat='disk size {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
-            prometheus.target(legendFormat='disk available {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
-            prometheus.target(legendFormat='disk utilization {{device}} {{nodename}} {{mountpoint}}', expr='round((sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename)) / (sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) + sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename)) * 100 * on(instance) group_left(nodename) (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
+            prometheus.target(legendFormat='disk used {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)  - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"} * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
+            prometheus.target(legendFormat='disk size {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
+            prometheus.target(legendFormat='disk available {{device}} {{nodename}} {{mountpoint}}', expr='sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))) by (device, instance, nodename)'),
+            prometheus.target(legendFormat='disk utilization {{device}} {{nodename}} {{mountpoint}}', expr='round((sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename)) / (sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename) + sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job", fstype!~"$diskfs"}) by (device, instance, nodename)) * 100 * on(instance) group_left(nodename) (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename)))'),
           ]
         ) { yaxes: std.mapWithIndex(function(i, item) if (i == 1) then item { show: false } else item, super.yaxes) };  // Hide second Y axis
 
@@ -217,9 +217,9 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/io time*/', yaxis: 2 })
         .addTargets(
           [
-            prometheus.target(legendFormat='read {{device}} {{nodename}}', expr='sum(rate(node_disk_read_bytes_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'),
-            prometheus.target(legendFormat='written {{device}} {{nodename}}', expr='sum(rate(node_disk_written_bytes_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'),
-            prometheus.target(legendFormat='io time {{device}} {{nodename}}', expr='sum(rate(node_disk_io_time_seconds_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'),
+            prometheus.target(legendFormat='read {{device}} {{nodename}}', expr='sum(rate(node_disk_read_bytes_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'),
+            prometheus.target(legendFormat='written {{device}} {{nodename}}', expr='sum(rate(node_disk_written_bytes_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'),
+            prometheus.target(legendFormat='io time {{device}} {{nodename}}', expr='sum(rate(node_disk_io_time_seconds_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'),
           ]
         );
 
@@ -234,8 +234,8 @@ local table = grafana.tablePanel;
         .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
         .addTargets(
           [
-            prometheus.target(legendFormat='Tx_{{device}} {{nodename}}', expr='rate(node_network_transmit_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'),
-            prometheus.target(legendFormat='Rx_{{device}} {{nodename}}', expr='rate(node_network_receive_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'),
+            prometheus.target(legendFormat='Tx_{{device}} {{nodename}}', expr='rate(node_network_transmit_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'),
+            prometheus.target(legendFormat='Rx_{{device}} {{nodename}}', expr='rate(node_network_receive_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'),
           ]
         );
 
@@ -247,7 +247,7 @@ local table = grafana.tablePanel;
           fill=0,
           min=0,
         )
-        .addTarget(prometheus.target(legendFormat='{{device}} {{nodename}}', expr='rate(node_network_receive_bytes_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'));
+        .addTarget(prometheus.target(legendFormat='{{device}} {{nodename}}', expr='rate(node_network_receive_bytes_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'));
 
       local netTransGraphPanel =
         graphPanel.new(
@@ -257,7 +257,7 @@ local table = grafana.tablePanel;
           fill=0,
           min=0,
         )
-        .addTarget(prometheus.target(legendFormat='{{device}} {{nodename}}', expr='rate(node_network_transmit_bytes_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) by (instance,nodename))'));
+        .addTarget(prometheus.target(legendFormat='{{device}} {{nodename}}', expr='rate(node_network_transmit_bytes_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   (avg(node_uname_info{cluster="$cluster", nodename=~"$instance"}) by (instance,nodename))'));
 
       dashboard.new(
         'Node Exporter',
@@ -271,8 +271,8 @@ local table = grafana.tablePanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(node_uname_info{cluster=~"$cluster"}, job)'),
-        $.grafanaTemplates.instanceTemplate('label_values(node_uname_info{cluster=~"$cluster", job=~"$job"}, nodename)'),
+        $.grafanaTemplates.jobTemplate('label_values(node_uname_info{cluster="$cluster"}, job)'),
+        $.grafanaTemplates.instanceTemplate('label_values(node_uname_info{cluster="$cluster", job=~"$job"}, nodename)'),
         $.grafanaTemplates.diskFileSystemsTemplate(),
       ])
       .addPanels(

--- a/jsonnet/dashboards/k8s/node-overview-dashboards.libsonnet
+++ b/jsonnet/dashboards/k8s/node-overview-dashboards.libsonnet
@@ -82,8 +82,8 @@ local polystatPanel = grafana.polystatPanel;
       .addSeriesOverride({ alias: '/Tx_/', stack: 'A' })
       .addTargets(
         [
-          prometheus.target(legendFormat='Tx_{{device}}', expr='rate(node_network_transmit_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='Rx_{{device}}', expr='rate(node_network_receive_errs_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='Tx_{{device}}', expr='rate(node_network_transmit_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='Rx_{{device}}', expr='rate(node_network_receive_errs_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
         ]
       )
       { tooltip+: { sort: 2 } }
@@ -97,7 +97,7 @@ local polystatPanel = grafana.polystatPanel;
         fill=0,
         min=0,
       )
-      .addTarget(prometheus.target(legendFormat='{{device}}', expr='rate(node_network_receive_bytes_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'))
+      .addTarget(prometheus.target(legendFormat='{{device}}', expr='rate(node_network_receive_bytes_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'))
       { tooltip+: { sort: 2 } }
       { gridPos: { x: 0, y: 14, w: 24, h: 7 } };
 
@@ -109,7 +109,7 @@ local polystatPanel = grafana.polystatPanel;
         fill=0,
         min=0,
       )
-      .addTarget(prometheus.target(legendFormat='{{device}}', expr='rate(node_network_transmit_bytes_total{cluster=~"$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'))
+      .addTarget(prometheus.target(legendFormat='{{device}}', expr='rate(node_network_transmit_bytes_total{cluster="$cluster", job=~"$job", device!~"lo|veth.+|docker.+|flannel.+|cali.+|cbr.|cni.+|br.+"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'))
       { tooltip+: { sort: 2 } }
       { gridPos: { x: 0, y: 21, w: 24, h: 7 } };
 
@@ -129,12 +129,12 @@ local polystatPanel = grafana.polystatPanel;
       .addSeriesOverride({ alias: '/free/', hiddenSeries: true })
       .addTargets(
         [
-          prometheus.target(legendFormat='memory used', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}) - sum by (nodename) (node_memory_MemAvailable_bytes{cluster=~"$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
-          prometheus.target(legendFormat='memory available', expr='sum by (nodename) (node_memory_MemAvailable_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
-          prometheus.target(legendFormat='memory buffers', expr='sum by (nodename) (node_memory_Buffers_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
-          prometheus.target(legendFormat='memory cached', expr='sum by (nodename) (node_memory_Cached_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
-          prometheus.target(legendFormat='memory free', expr='sum by (nodename) (node_memory_MemFree_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
-          prometheus.target(legendFormat='memory total', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory used', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}) - sum by (nodename) (node_memory_MemAvailable_bytes{cluster="$cluster", job=~"$job"} * on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory available', expr='sum by (nodename) (node_memory_MemAvailable_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory buffers', expr='sum by (nodename) (node_memory_Buffers_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory cached', expr='sum by (nodename) (node_memory_Cached_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory free', expr='sum by (nodename) (node_memory_MemFree_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='memory total', expr='sum by (nodename) (node_memory_MemTotal_bytes{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
         ]
       )
       { tooltip+: { sort: 2 } }
@@ -155,10 +155,10 @@ local polystatPanel = grafana.polystatPanel;
       .addSeriesOverride({ alias: '/utilization/', yaxis: 2, lines: false, legend: false, pointradius: 0 })
       .addTargets(
         [
-          prometheus.target(legendFormat='disk used {{device}}', expr='(sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance))\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='disk size {{device}}', expr='sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='disk available {{device}}', expr='sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='disk utilization {{device}}', expr='round((sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename)) / (sum(node_filesystem_size_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename) + sum(node_filesystem_avail_bytes{cluster=~"$cluster", job=~"$job"}) by (device, instance, nodename)) * 100 * on(instance) group_left(nodename) node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='disk used {{device}}', expr='(sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (device, instance) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job"}) by (device, instance))\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='disk size {{device}}', expr='sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (device, instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='disk available {{device}}', expr='sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job"}) by (device, instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='disk utilization {{device}}', expr='round((sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename)) / (sum(node_filesystem_size_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename) - sum(node_filesystem_free_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename) + sum(node_filesystem_avail_bytes{cluster="$cluster", job=~"$job"}) by (device, instance, nodename)) * 100 * on(instance) group_left(nodename) node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
         ]
       )
       { yaxes: std.mapWithIndex(function(i, item) if (i == 1) then item { show: false } else item, super.yaxes) }  // Hide second Y axis
@@ -177,9 +177,9 @@ local polystatPanel = grafana.polystatPanel;
       .addSeriesOverride({ alias: '/io time*/', yaxis: 2 })
       .addTargets(
         [
-          prometheus.target(legendFormat='read {{device}}', expr='sum(rate(node_disk_read_bytes_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='written {{device}}', expr='sum(rate(node_disk_written_bytes_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='io time {{device}}', expr='sum(rate(node_disk_io_time_seconds_total{cluster=~"$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='read {{device}}', expr='sum(rate(node_disk_read_bytes_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='written {{device}}', expr='sum(rate(node_disk_written_bytes_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='io time {{device}}', expr='sum(rate(node_disk_io_time_seconds_total{cluster="$cluster", job=~"$job"}[5m])) by (instance)\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
         ]
       )
       { tooltip+: { sort: 2 } }
@@ -195,7 +195,7 @@ local polystatPanel = grafana.polystatPanel;
         min=0,
         max=100,
       )
-      .addTarget(prometheus.target(legendFormat='cpu usage', expr='round((1 - (avg(irate(node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="idle"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}))) * 100)'))
+      .addTarget(prometheus.target(legendFormat='cpu usage', expr='round((1 - (avg(irate(node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="idle"}[5m])\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}))) * 100)'))
       { tooltip+: { sort: 2 } }
       { gridPos: { x: 0, y: 7, w: 24, h: 7 } };
 
@@ -209,10 +209,10 @@ local polystatPanel = grafana.polystatPanel;
       .addSeriesOverride({ alias: 'logical cores', linewidth: 2, color: '#C4162A' })
       .addTargets(
         [
-          prometheus.target(legendFormat='1m load average', expr='node_load1{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='5m load average', expr='node_load5{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='15m load average', expr='node_load15{cluster=~"$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"}'),
-          prometheus.target(legendFormat='logical cores', expr='count(node_cpu_seconds_total{cluster=~"$cluster", job=~"$job", mode="idle"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster=~"$cluster", nodename=~"$instance"})'),
+          prometheus.target(legendFormat='1m load average', expr='node_load1{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='5m load average', expr='node_load5{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='15m load average', expr='node_load15{cluster="$cluster", job=~"$job"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"}'),
+          prometheus.target(legendFormat='logical cores', expr='count(node_cpu_seconds_total{cluster="$cluster", job=~"$job", mode="idle"}\n* on(instance) group_left(nodename) \n   node_uname_info{cluster="$cluster", nodename=~"$instance"})'),
         ]
       )
       { tooltip+: { sort: 2 } }
@@ -229,7 +229,7 @@ local polystatPanel = grafana.polystatPanel;
       grafanaTemplates=[
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster=~"$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
+        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster="$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
       ]
     ) +
 
@@ -244,7 +244,7 @@ local polystatPanel = grafana.polystatPanel;
       grafanaTemplates=[
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster=~"$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
+        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster="$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
       ]
     ) +
 
@@ -259,7 +259,7 @@ local polystatPanel = grafana.polystatPanel;
       grafanaTemplates=[
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster=~"$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
+        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster="$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
       ]
     ) +
 
@@ -274,7 +274,7 @@ local polystatPanel = grafana.polystatPanel;
       grafanaTemplates=[
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(node_uname_info, cluster)'),
-        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster=~"$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
+        $.grafanaTemplates.jobTemplate('label_values(node_exporter_build_info{cluster="$cluster", pod!~"virt-launcher.*|"}, job)', hide='variable'),
       ]
     ),
 

--- a/jsonnet/dashboards/k8s/proxy.libsonnet
+++ b/jsonnet/dashboards/k8s/proxy.libsonnet
@@ -40,7 +40,7 @@ local statPanel = grafana.statPanel;
           min=0,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='rate')),
+        .addTarget(prometheus.target('sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster="$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='rate')),
 
       local rulesSyncLatency =
         graphPanel.new(
@@ -53,7 +53,7 @@ local statPanel = grafana.statPanel;
           legend_rightSide=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster="$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local networkProgrammingRate =
         graphPanel.new(
@@ -62,7 +62,7 @@ local statPanel = grafana.statPanel;
           min=0,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='rate')),
+        .addTarget(prometheus.target('sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster="$cluster", %(proxy)s, instance=~"$instance"}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='rate')),
 
       local networkProgrammingLatency =
         graphPanel.new(
@@ -75,7 +75,7 @@ local statPanel = grafana.statPanel;
           legend_rightSide=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster="$cluster", %(proxy)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local kubeApiRequestRate =
         graphPanel.new(
@@ -85,10 +85,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(proxy)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(proxy)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(proxy)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(proxy)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(proxy)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(proxy)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(proxy)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(proxy)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
           ]
         ),
 
@@ -99,7 +99,7 @@ local statPanel = grafana.statPanel;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(proxy)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(proxy)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local getRequestLatency =
         graphPanel.new(
@@ -112,7 +112,7 @@ local statPanel = grafana.statPanel;
           legend_rightSide=true,
           legend_values=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(proxy)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(proxy)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local memory =
         graphPanel.new(
@@ -120,7 +120,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(proxy)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local cpu =
         graphPanel.new(
@@ -128,14 +128,14 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", %(proxy)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", %(proxy)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", %(proxy)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       dashboard:
         dashboard.new(
@@ -150,7 +150,7 @@ local statPanel = grafana.statPanel;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(workqueue_adds_total, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster=~"$cluster", %(proxy)s}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster="$cluster", %(proxy)s}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/pvc.libsonnet
+++ b/jsonnet/dashboards/k8s/pvc.libsonnet
@@ -55,25 +55,25 @@ local graphPanel = grafana.graphPanel;
         usageGraphPanel(title='Volume Space Usage', format='bytes')
         .addTargets(
           [
-            prometheus.target(legendFormat='Used Space {{persistentvolumeclaim}}', expr='(\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)' % $._config.grafanaDashboards.selectors),
-            prometheus.target(legendFormat='Free Space {{persistentvolumeclaim}}', expr='sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})' % $._config.grafanaDashboards.selectors),
+            prometheus.target(legendFormat='Used Space {{persistentvolumeclaim}}', expr='(\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)' % $._config.grafanaDashboards.selectors),
+            prometheus.target(legendFormat='Free Space {{persistentvolumeclaim}}', expr='sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})' % $._config.grafanaDashboards.selectors),
           ]
         );
 
       local volSpaceUsageGaugePanel =
-        usageGaugePanel(title='Volume Space Usage', expr='(\n  sum(kubelet_volume_stats_capacity_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum(kubelet_volume_stats_available_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)\n/\nsum(kubelet_volume_stats_capacity_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n* 100' % $._config.grafanaDashboards.selectors);
+        usageGaugePanel(title='Volume Space Usage', expr='(\n  sum(kubelet_volume_stats_capacity_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum(kubelet_volume_stats_available_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)\n/\nsum(kubelet_volume_stats_capacity_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n* 100' % $._config.grafanaDashboards.selectors);
 
       local volInodesUsageGraphPanel =
         usageGraphPanel(title='Volume inodes Usage', format='none')
         .addTargets(
           [
-            prometheus.target(legendFormat='Used inodes {{persistentvolumeclaim}}', expr='sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes_used{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})' % $._config.grafanaDashboards.selectors),
-            prometheus.target(legendFormat='Free inodes {{persistentvolumeclaim}}', expr='(\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace="$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes_used{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)' % $._config.grafanaDashboards.selectors),
+            prometheus.target(legendFormat='Used inodes {{persistentvolumeclaim}}', expr='sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes_used{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})' % $._config.grafanaDashboards.selectors),
+            prometheus.target(legendFormat='Free inodes {{persistentvolumeclaim}}', expr='(\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace="$namespace", persistentvolumeclaim=~"$pvc"})\n  -\n  sum by (persistentvolumeclaim) (kubelet_volume_stats_inodes_used{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n)' % $._config.grafanaDashboards.selectors),
           ]
         );
 
       local volInodesUsageGaugePanel =
-        usageGaugePanel(title='Volume inodes Usage', expr='sum(kubelet_volume_stats_inodes_used{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n/\nsum(kubelet_volume_stats_inodes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n* 100' % $._config.grafanaDashboards.selectors);
+        usageGaugePanel(title='Volume inodes Usage', expr='sum(kubelet_volume_stats_inodes_used{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n/\nsum(kubelet_volume_stats_inodes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace", persistentvolumeclaim=~"$pvc"})\n* 100' % $._config.grafanaDashboards.selectors);
 
       dashboard.new(
         'Persistent Volumes',
@@ -87,8 +87,8 @@ local graphPanel = grafana.graphPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(kubelet_volume_stats_capacity_bytes, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kubelet_volume_stats_capacity_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics"}, namespace)' % $._config.grafanaDashboards.selectors),
-        $.grafanaTemplates.pvcTemplate('label_values(kubelet_volume_stats_capacity_bytes{cluster=~"$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace"}, persistentvolumeclaim)' % $._config.grafanaDashboards.selectors),
+        $.grafanaTemplates.namespaceTemplate('label_values(kubelet_volume_stats_capacity_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics"}, namespace)' % $._config.grafanaDashboards.selectors),
+        $.grafanaTemplates.pvcTemplate('label_values(kubelet_volume_stats_capacity_bytes{cluster="$cluster", %(kubelet)s, metrics_path="/metrics", namespace=~"$namespace"}, persistentvolumeclaim)' % $._config.grafanaDashboards.selectors),
       ])
       .addPanels(
         [

--- a/jsonnet/dashboards/k8s/scheduler.libsonnet
+++ b/jsonnet/dashboards/k8s/scheduler.libsonnet
@@ -46,10 +46,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} e2e'),
-            prometheus.target('sum(rate(scheduler_binding_duration_seconds_count{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} binding'),
-            prometheus.target('sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} scheduling algorithm'),
-            prometheus.target('sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} volume'),
+            prometheus.target('sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} e2e'),
+            prometheus.target('sum(rate(scheduler_binding_duration_seconds_count{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} binding'),
+            prometheus.target('sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} scheduling algorithm'),
+            prometheus.target('sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance)' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} volume'),
           ]
         ),
 
@@ -66,10 +66,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} e2e'),
-            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} binding'),
-            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} scheduling algorithm'),
-            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} volume'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} e2e'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} binding'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} scheduling algorithm'),
+            prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}} volume'),
           ]
         ),
 
@@ -82,10 +82,10 @@ local statPanel = grafana.statPanel;
         )
         .addTargets(
           [
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
-            prometheus.target('sum(rate(rest_client_requests_total{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(scheduler)s, instance=~"$instance", code=~"2.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='2xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(scheduler)s, instance=~"$instance", code=~"3.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='3xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(scheduler)s, instance=~"$instance", code=~"4.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='4xx'),
+            prometheus.target('sum(rate(rest_client_requests_total{cluster="$cluster", %(scheduler)s, instance=~"$instance", code=~"5.."}[5m]))' % $._config.grafanaDashboards.selectors, legendFormat='5xx'),
           ]
         ),
 
@@ -96,7 +96,7 @@ local statPanel = grafana.statPanel;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local getRequestLatency =
         graphPanel.new(
@@ -109,7 +109,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=~"$cluster", %(scheduler)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster="$cluster", %(scheduler)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config.grafanaDashboards.selectors, legendFormat='{{verb}} {{url}}')),
 
       local memory =
         graphPanel.new(
@@ -117,7 +117,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('process_resident_memory_bytes{cluster="$cluster", %(scheduler)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local cpu =
         graphPanel.new(
@@ -125,14 +125,14 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{cluster="$cluster", %(scheduler)s, instance=~"$instance"}[5m])' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       local goroutines =
         graphPanel.new(
           title='Goroutines',
           datasource='$datasource',
         )
-        .addTarget(prometheus.target('go_goroutines{cluster=~"$cluster", %(scheduler)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
+        .addTarget(prometheus.target('go_goroutines{cluster="$cluster", %(scheduler)s, instance=~"$instance"}' % $._config.grafanaDashboards.selectors, legendFormat='{{instance}}')),
 
       dashboard:
         dashboard.new(
@@ -147,7 +147,7 @@ local statPanel = grafana.statPanel;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.clusterTemplate('label_values(scheduler_e2e_scheduling_duration_seconds_count, cluster)'),
-          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster=~"$cluster", %(scheduler)s}, instance)' % $._config.grafanaDashboards.selectors),
+          $.grafanaTemplates.instanceTemplate('label_values(process_cpu_seconds_total{cluster="$cluster", %(scheduler)s}, instance)' % $._config.grafanaDashboards.selectors),
         ])
         .addPanels(
           [

--- a/jsonnet/dashboards/k8s/statefulset.libsonnet
+++ b/jsonnet/dashboards/k8s/statefulset.libsonnet
@@ -36,46 +36,46 @@ local graphPanel = grafana.graphPanel;
       local cpuPanel =
         panel(
           title='CPU',
-          expr='sum(rate(container_cpu_usage_seconds_total{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster=~"$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m]))' % $._config.grafanaDashboards.selectors,
+          expr='sum(rate(container_cpu_usage_seconds_total{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster="$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m]))' % $._config.grafanaDashboards.selectors,
           unit='cores',
         );
 
       local memoryPanel =
         panel(
           title='Memory',
-          expr='sum(container_memory_working_set_bytes{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster=~"$cluster", namespace=~"$namespace", pod=~"$statefulset.*", container!~"POD|", id!=""})' % $._config.grafanaDashboards.selectors,
+          expr='sum(container_memory_working_set_bytes{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster="$cluster", namespace=~"$namespace", pod=~"$statefulset.*", container!~"POD|", id!=""})' % $._config.grafanaDashboards.selectors,
           unit='bytes',
         );
 
       local networkPanel =
         panel(
           title='Network',
-          expr='sum(rate(container_network_transmit_bytes_total{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster=~"$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m])) + sum(rate(container_network_receive_bytes_total{cluster=~"$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m]))' % $._config.grafanaDashboards.selectors,
+          expr='sum(rate(container_network_transmit_bytes_total{%(kubelet)s, metrics_path="/metrics/cadvisor", cluster="$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m])) + sum(rate(container_network_receive_bytes_total{cluster="$cluster", namespace=~"$namespace", pod=~"$statefulset.*"}[5m]))' % $._config.grafanaDashboards.selectors,
           unit='Bps',
         );
 
       local desiredReplicasPanel =
         panel(
           title='Desired Replicas',
-          expr='sum(kube_statefulset_status_replicas{cluster=~"$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
+          expr='sum(kube_statefulset_status_replicas{cluster="$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
         );
 
       local currentReplicasPanel =
         panel(
           title='Replicas of current version',
-          expr='sum(kube_statefulset_status_replicas_current{cluster=~"$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
+          expr='sum(kube_statefulset_status_replicas_current{cluster="$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
         );
 
       local observedGenerationPanel =
         panel(
           title='Observed Generation',
-          expr='sum(kube_statefulset_status_observed_generation{cluster=~"$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
+          expr='sum(kube_statefulset_status_observed_generation{cluster="$cluster", namespace=~"$namespace", statefulset=~"$statefulset"})',
         );
 
       local metadataGenerationPanel =
         panel(
           title='Metadata Generation',
-          expr='sum(kube_statefulset_metadata_generation{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"})',
+          expr='sum(kube_statefulset_metadata_generation{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"})',
         );
 
       local replicasGraphPanel =
@@ -85,11 +85,11 @@ local graphPanel = grafana.graphPanel;
         )
         .addTargets(
           [
-            prometheus.target(legendFormat='replicas specified {{statefulset}}', expr='sum(kube_statefulset_replicas{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"}) by (statefulset)'),
-            prometheus.target(legendFormat='replicas created {{statefulset}}', expr='sum(kube_statefulset_status_replicas{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"}) by (statefulset)'),
-            prometheus.target(legendFormat='ready {{statefulset}}', expr='sum(kube_statefulset_status_replicas_ready{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"}) by (statefulset)'),
-            prometheus.target(legendFormat='replicas of current version {{statefulset}}', expr='sum(kube_statefulset_status_replicas_current{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"}) by (statefulset)'),
-            prometheus.target(legendFormat='updated {{statefulset}}', expr='sum(kube_statefulset_status_replicas_updated{statefulset=~"$statefulset", cluster=~"$cluster", namespace=~"$namespace"}) by (statefulset)'),
+            prometheus.target(legendFormat='replicas specified {{statefulset}}', expr='sum(kube_statefulset_replicas{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"}) by (statefulset)'),
+            prometheus.target(legendFormat='replicas created {{statefulset}}', expr='sum(kube_statefulset_status_replicas{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"}) by (statefulset)'),
+            prometheus.target(legendFormat='ready {{statefulset}}', expr='sum(kube_statefulset_status_replicas_ready{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"}) by (statefulset)'),
+            prometheus.target(legendFormat='replicas of current version {{statefulset}}', expr='sum(kube_statefulset_status_replicas_current{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"}) by (statefulset)'),
+            prometheus.target(legendFormat='updated {{statefulset}}', expr='sum(kube_statefulset_status_replicas_updated{statefulset=~"$statefulset", cluster="$cluster", namespace=~"$namespace"}) by (statefulset)'),
           ]
         );
 
@@ -105,8 +105,8 @@ local graphPanel = grafana.graphPanel;
       .addTemplates([
         $.grafanaTemplates.datasourceTemplate(),
         $.grafanaTemplates.clusterTemplate('label_values(kube_statefulset_metadata_generation, cluster)'),
-        $.grafanaTemplates.namespaceTemplate('label_values(kube_statefulset_metadata_generation{cluster=~"$cluster"}, namespace)'),
-        $.grafanaTemplates.statefulsetTemplate('label_values(kube_statefulset_metadata_generation{cluster=~"$cluster", namespace=~"$namespace"}, statefulset)'),
+        $.grafanaTemplates.namespaceTemplate('label_values(kube_statefulset_metadata_generation{cluster="$cluster"}, namespace)'),
+        $.grafanaTemplates.statefulsetTemplate('label_values(kube_statefulset_metadata_generation{cluster="$cluster", namespace=~"$namespace"}, statefulset)'),
       ])
       .addPanels(
         [

--- a/jsonnet/dashboards/monitoring.libsonnet
+++ b/jsonnet/dashboards/monitoring.libsonnet
@@ -136,9 +136,9 @@ local getClusterRowGridY(numOfClusters, panelWidth, panelHeight) =
             local panelHeight = tpl.panel.gridPos.h;
             local panelWidth = tpl.panel.gridPos.w;
 
-            local clusterLabel = if std.objectHas(cluster, 'label') then cluster.label else '.*';
+            local clusterLabel = cluster.label;
 
-            local dataLinkCommonArgs = std.strReplace($._config.grafanaDashboards.dataLinkCommonArgs, '$cluster|', clusterLabel);
+            local dataLinkCommonArgs = std.strReplace($._config.grafanaDashboards.dataLinkCommonArgs, '$cluster', clusterLabel);
 
             local gridX =
               if std.type(tpl.panel.gridPos.x) == 'number' then
@@ -185,7 +185,7 @@ local getClusterRowGridY(numOfClusters, panelWidth, panelHeight) =
                   tpl.panel.dataLinks
                 else
                   [{ title: 'Kubernetes Monitoring', url: '/d/%s?%s' % [getUid($._config.grafanaDashboards.ids.k8sMonitoring, cluster, $._config.templates.L1.k8s), dataLinkCommonArgs] }]
-               )
+              )
             )
             {
               gridPos: {

--- a/jsonnet/dashboards/vms/alert-overview.libsonnet
+++ b/jsonnet/dashboards/vms/alert-overview.libsonnet
@@ -38,8 +38,8 @@ local table = grafana.tablePanel;
             { alias: 'Alertname', pattern: 'alertname', type: 'string' },
             { alias: 'Job', pattern: 'job', type: 'string' },
             { alias: 'Node', pattern: 'nodename', type: 'string' },
-            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row'},
-            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row'},
+            { alias: 'warningCode', pattern: 'Value #A', type: 'number', thresholds: warning_thresholds, colors: colors, colorMode: 'row' },
+            { alias: 'criticalCode  ', pattern: 'Value #B', type: 'number', thresholds: critical_thresholds, colors: colors, colorMode: 'row' },
           ]
         )
         .addTargets([

--- a/jsonnet/dashboards/vms/vm-monitoring.libsonnet
+++ b/jsonnet/dashboards/vms/vm-monitoring.libsonnet
@@ -175,7 +175,7 @@ local text = grafana.text;
         .addTemplates([
           $.grafanaTemplates.datasourceTemplate(),
           $.grafanaTemplates.alertManagerTemplate(),
-          $.grafanaTemplates.jobTemplate('label_values(node_uname_info{cluster=~"$cluster", pod=~"virt-launcher.*"}, job)', hide='variable'),
+          $.grafanaTemplates.jobTemplate('label_values(node_uname_info{cluster="$cluster", pod=~"virt-launcher.*"}, job)', hide='variable'),
         ])
         .addPanels(
           [

--- a/jsonnet/rules/apps/rules.libsonnet
+++ b/jsonnet/rules/apps/rules.libsonnet
@@ -55,9 +55,9 @@
     if std.length(k8sAppAlerts) > 0 || std.length(hostAppAlerts) > 0 || std.length(vmAppAlerts) > 0 then
       {
         'apps.rules': {
-          local alertGroupK8sApps = { alertgroup : $._config.prometheusRules.alertGroupClusterApp },
-          local alertGroupHostApps = { alertgroup : $._config.prometheusRules.alertGroupHostApp },
-          local alertGroupVmApps  = { alertgroup : $._config.prometheusRules.alertGroupClusterVMApp },
+          local alertGroupK8sApps = { alertgroup: $._config.prometheusRules.alertGroupClusterApp },
+          local alertGroupHostApps = { alertgroup: $._config.prometheusRules.alertGroupHostApp },
+          local alertGroupVmApps = { alertgroup: $._config.prometheusRules.alertGroupClusterVMApp },
           groups: [
             $.newRuleGroup('k8sApps.rules')
             .addRules(

--- a/jsonnet/util.libsonnet
+++ b/jsonnet/util.libsonnet
@@ -92,9 +92,6 @@
   isHostMonitoring()::
     $._config.hostMonitoring.enabled && std.length($._config.hostMonitoring.hosts) > 0,
 
-  isMultiClusterMonitoring()::
-    $._config.clusterMonitoring.enabled && std.length($._config.clusterMonitoring.clusters) > 1,
-
   dashboardTemplateMapping():: {
     /**
      * Maps dashboards to their template group. User defined templates from values.yaml are included too.
@@ -429,19 +426,16 @@
 
   updateDataLinksCommonArgs(datalinks, tableLink=false)::
     /**
-     * If monitoring is in multi-cluster setup, we want to pass variable $cluster between dashboards.
-     * If monitoring is in single-cluster setup, only '$cluster|' is passed which match everything.
      *
      * @param array Datalinks for panel.
      * @param boolean tableLink if processed datalinks are from table or panels.
      * @return array Datalinks for panel.
      */
-    local clusterLabel = if utils.isMultiClusterMonitoring() then '$cluster' else '$cluster|';
     local urlField = if tableLink then 'linkUrl' else 'url';
     [
       local urlFieldValue = if tableLink then datalink.linkUrl else datalink.url;
       if std.objectHas(datalink, urlField) then
-        datalink { [urlField]: std.strReplace(urlFieldValue, '$cluster|', clusterLabel) }
+        datalink { [urlField]: urlFieldValue }
       else
         datalink
       for datalink in datalinks


### PR DESCRIPTION
Also, there is no distinction between single and multicluster monitoring now, every cluster should have a 'cluster' label

Related to SovereignCloudStack/issues#305