### PR TITLE
Update blackbox exporter variables

### DIFF
--- a/jsonnet/config.libsonnet
+++ b/jsonnet/config.libsonnet
@@ -59,7 +59,7 @@
       },
       dataLinkCommonArgs: 'refresh=%s&var-datasource=$datasource&var-cluster=$cluster&from=$__from&to=$__to' % [self.refresh],
       dataLinkCommonArgsNoCluster: 'refresh=%s&var-datasource=$datasource&from=$__from&to=$__to' % [self.refresh],
-      dataLinkCommonArgsBlackbox: 'refresh=%s&var-datasource=$datasource&var-instance=$http_endpoint&from=$__from&to=$__to' % [self.refresh],
+      dataLinkCommonArgsBlackbox: 'refresh=%s&var-datasource=$datasource&var-target=$target&from=$__from&to=$__to' % [self.refresh],
       templateRefresh: 'time',  // on time range change
       templateSort: 5,  // case insensitive ascent sort
       ids: {

--- a/jsonnet/dashboards/grafana-templates.libsonnet
+++ b/jsonnet/dashboards/grafana-templates.libsonnet
@@ -99,10 +99,10 @@ local template = grafana.template;
         label='Severity',
       ),
 
-    httpTemplate(query, hide='', multi=true, includeAll=true, current='All')::
+    targetTemplate(query, hide='', multi=true, includeAll=true, current='All')::
       baseTemplate(
-        name='http_endpoint',
-        label='HTTP Endpoint',
+        name='target',
+        label='Service Target',
         query=query,
         includeAll=includeAll,
         multi=multi,

--- a/jsonnet/dashboards/monitoring.libsonnet
+++ b/jsonnet/dashboards/monitoring.libsonnet
@@ -173,12 +173,12 @@ local getClusterRowGridY(numOfClusters, panelWidth, panelHeight) =
                 );
 
             statPanel.new(
-              title='$http_endpoint',
+              title='$target',
               datasource=tpl.panel.datasource,
               graphMode=tpl.panel.graphMode,
               colorMode=tpl.panel.colorMode,
               unit=tpl.panel.unit,
-              repeat='http_endpoint',
+              repeat='target',
               decimals=tpl.panel.decimals,
               maxPerRow=4,
             )
@@ -186,7 +186,7 @@ local getClusterRowGridY(numOfClusters, panelWidth, panelHeight) =
               {
                 type: 'single',
                 instant: true,
-                expr: tpl.panel.expr % { http_endpoint: '$http_endpoint' },
+                expr: tpl.panel.expr % { target: '$target' },
               }
             )
             .addThresholds($.grafanaThresholds(tpl.panel.thresholds))
@@ -230,7 +230,7 @@ local getClusterRowGridY(numOfClusters, panelWidth, panelHeight) =
           .addTemplates([
             $.grafanaTemplates.datasourceTemplate(),
             $.grafanaTemplates.alertManagerTemplate(),
-            $.grafanaTemplates.httpTemplate('label_values(probe_http_version{endpoint="http"},instance)', multi=true, includeAll=true, current='All'),
+            $.grafanaTemplates.targetTemplate('label_values(probe_success{endpoint="http"},target)', multi=true, includeAll=true, current='All'),
           ])
           .addPanels(
             (

--- a/jsonnet/templates.libsonnet
+++ b/jsonnet/templates.libsonnet
@@ -1803,7 +1803,7 @@
       local maxWarnings = $.defaultConfig.grafanaDashboards.constants.maxWarnings,
       blackbox: {
         main: {
-          local expr = 'probe_success{instance=~"%(http_endpoint)s", endpoint="http"}',
+          local expr = 'probe_success{target=~"%(target)s", endpoint="http"}',
           local thresholds = {
             operator: '<',
             lowest: 0,


### PR DESCRIPTION
Use a human-readable `target` instead of `http_endpoint` as a variable for filtering