### PR TITLE
Fix issue with host-alert panel for grafana 10

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,8 +15,8 @@
 
 apiVersion: v2
 name: dnation-kubernetes-monitoring
-version: 2.7.0
-appVersion: 2.7.0
+version: 2.7.1
+appVersion: 2.7.1
 description: A set of Grafana dashboards and Prometheus alerts to cover Kubernetes monitoring in an easy way using a drill-down principle.
 keywords:
 - dnation

--- a/jsonnet/dashboards/hosts/alert-overview.libsonnet
+++ b/jsonnet/dashboards/hosts/alert-overview.libsonnet
@@ -65,9 +65,6 @@ local table = grafana.tablePanel;
               },
             },
           },
-          {
-            id: 'seriesToRows',
-          },
         ]);
 
       dashboard.new(


### PR DESCRIPTION
This PR should fix the issue with the host alert panel, which is broken in Grafana 10. See the attached picture.

![alert-host-panel](https://github.com/user-attachments/assets/5cc81894-282c-4f9f-9988-5c8fc3d7f34c)
