### PR TITLE
fix: changelog and docs workflows

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.1.2
-mkdocs-material==6.1.7
-mkdocs-material-extensions==1.0.1
+mkdocs==1.6.1
+mkdocs-material==9.6.19
+mkdocs-material-extensions==1.3.1
 mkdocs-exclude==1.0.2
-ruamel.yaml==0.16.12
+ruamel.yaml==0.17.40
 jsonnet==0.16.0


### PR DESCRIPTION
Changelog workflow previously failed due to insufficient token permissions. Docs workflow failed due to MkDocs version mismatch. Updated docs/requirements.txt to compatible versions. Added bot to a PR bypass.