### PR TITLE
Update CI/CD jsonnet image to jsonnet 0.20 and grafonnet v13

### DIFF
--- a/helpers/ci_cd_image/Dockerfile
+++ b/helpers/ci_cd_image/Dockerfile
@@ -1,11 +1,12 @@
-FROM golang:1.15.2-alpine3.12 AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git
 
+# go-jsonnet v0.22.0 (adds std.get etc., required by grafana/grafonnet v13)
 RUN git clone https://github.com/google/go-jsonnet.git && \
     cd go-jsonnet && \
-    git reset --hard 31d71aaccda6d98135ecc02acae823ef6e78270c && \
+    git checkout v0.22.0 && \
     go build ./cmd/jsonnet && \
     go build ./cmd/jsonnetfmt && \
     go build ./cmd/jsonnet-lint
@@ -13,26 +14,29 @@ RUN git clone https://github.com/google/go-jsonnet.git && \
 RUN wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /go/yq && \
     chmod +x /go/yq
 
-RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb && \
-    jb init && \
-    jb install https://github.com/grafana/grafonnet-lib/grafonnet@daad85cf3fad3580e58029414630e29956aefe21 && \
-    jb install https://github.com/thelastpickle/grafonnet-polystat-panel@275a48de57afdac0d72219d82863d8ab8bd0e682
+# grafana/grafonnet v13 (gen/grafonnet-latest) + polystat panel vendored into /vendor
+RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0
+WORKDIR /go
+RUN jb init && \
+    jb install github.com/grafana/grafonnet/gen/grafonnet-latest@41e6bfcbe4ef1054298ffff8664f1354c897dd2d && \
+    jb install github.com/thelastpickle/grafonnet-polystat-panel@275a48de57afdac0d72219d82863d8ab8bd0e682
 
-FROM alpine:3.12
+FROM alpine:3.20
 
-LABEL Version="1.0.3"
+LABEL Version="2.0.0"
 LABEL Vendor="dNation"
 LABEL Description="CI/CD jsonnet docker image"
 
-LABEL JsonnetVersion="fe2809577220c8c06810e842c074f0f0820e9169"
+LABEL JsonnetVersion="v0.22.0"
 LABEL YqVersion="3.4.1"
-LABEL GrafonnetVersion="daad85cf3fad3580e58029414630e29956aefe21"
+LABEL GrafonnetVersion="41e6bfcbe4ef1054298ffff8664f1354c897dd2d"
 LABEL GrafonnetPolystatPanelVersion="275a48de57afdac0d72219d82863d8ab8bd0e682"
 
 RUN addgroup -S jsonnet && adduser -S -G jsonnet jsonnet
 
 COPY --from=builder /go/vendor vendor
 COPY --from=builder /go/go-jsonnet/jsonnet* /usr/local/bin/
+COPY --from=builder /go/bin/jb /usr/local/bin/
 COPY --from=builder /go/yq /usr/local/bin/
 RUN chmod -R 777 /vendor
 


### PR DESCRIPTION
We're migrating our Grafana dashboards from the deprecated [`grafonnet-lib`](https://github.com/grafana/grafonnet-lib) to the current [`grafana/grafonnet`](https://github.com/grafana/grafonnet) library (v13, for native Grafana 13).

The new library relies on `std.get`, which was added in jsonnet **0.18.0** — but
the CI/CD image ships jsonnet **0.17.0**, so `make json-dashboards` / `jsonnet-lint`
fail with `RUNTIME ERROR: Field does not exist: get`.

- The image is built & pushed manually to Docker Hub — `dnationcloud/jsonnet:2.0.0` + `:latest` already pushed